### PR TITLE
Add API Implementation to HTTP Client

### DIFF
--- a/client/http_requests.go
+++ b/client/http_requests.go
@@ -166,3 +166,32 @@ func (c *HTTPClient) GetTransferFeeInfo(accountIndex, toAccountIndex int64, auth
 	}
 	return result, nil
 }
+
+// OrderBookDetails Get data about a specific market’s orderbook
+// Docs: https://apidocs.lighter.xyz/reference/orderbookdetails
+// GET https://mainnet.zklighter.elliot.ai/api/v1/orderBookDetails
+func (c *HTTPClient) OrderBookDetails(marketId uint8) (*OrderBookDetails, error) {
+	result := &OrderBookDetails{}
+	err := c.getAndParseL2HTTPResponse("api/v1/orderBookDetails", map[string]any{
+		"market_id": marketId,
+	}, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// OrderBookOrders Get order book orders
+// Docs: https://apidocs.lighter.xyz/reference/orderbookorders
+// GET https://mainnet.zklighter.elliot.ai/api/v1/orderBookOrders
+func (c *HTTPClient) OrderBookOrders(marketId uint8, limit int64) (*OrderBookOrders, error) {
+	result := &OrderBookOrders{}
+	err := c.getAndParseL2HTTPResponse("api/v1/orderBookOrders", map[string]any{
+		"market_id": marketId,
+		"limit":     limit,
+	}, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/client/http_types.go
+++ b/client/http_types.go
@@ -82,3 +82,64 @@ type TransferFeeInfo struct {
 	ResultCode
 	TransferFee int64 `json:"transfer_fee_usdc"`
 }
+
+type OrderBookDetails struct {
+	ResultCode
+	OrderBookDetails []OrderBookDetail `json:"order_book_details"`
+}
+
+type OrderBookDetail struct {
+	Symbol                       string  `json:"symbol"`
+	MarketID                     int     `json:"market_id"`
+	Status                       string  `json:"status"`
+	TakerFee                     string  `json:"taker_fee"`
+	MakerFee                     string  `json:"maker_fee"`
+	LiquidationFee               string  `json:"liquidation_fee"`
+	MinBaseAmount                string  `json:"min_base_amount"`
+	MinQuoteAmount               string  `json:"min_quote_amount"`
+	OrderQuoteLimit              string  `json:"order_quote_limit"`
+	SupportedSizeDecimals        int     `json:"supported_size_decimals"`
+	SupportedPriceDecimals       int     `json:"supported_price_decimals"`
+	SupportedQuoteDecimals       int     `json:"supported_quote_decimals"`
+	SizeDecimals                 int     `json:"size_decimals"`
+	PriceDecimals                int     `json:"price_decimals"`
+	QuoteMultiplier              int     `json:"quote_multiplier"`
+	DefaultInitialMarginFraction int     `json:"default_initial_margin_fraction"`
+	MinInitialMarginFraction     int     `json:"min_initial_margin_fraction"`
+	MaintenanceMarginFraction    int     `json:"maintenance_margin_fraction"`
+	CloseoutMarginFraction       int     `json:"closeout_margin_fraction"`
+	LastTradePrice               float64 `json:"last_trade_price"`
+	DailyTradesCount             int     `json:"daily_trades_count"`
+	DailyBaseTokenVolume         float64 `json:"daily_base_token_volume"`
+	DailyQuoteTokenVolume        float64 `json:"daily_quote_token_volume"`
+	DailyPriceLow                float64 `json:"daily_price_low"`
+	DailyPriceHigh               float64 `json:"daily_price_high"`
+	DailyPriceChange             float64 `json:"daily_price_change"`
+	OpenInterest                 float64 `json:"open_interest"`
+	DailyChart                   struct {
+	} `json:"daily_chart"`
+	MarketConfig MarketConfig `json:"market_config"`
+}
+
+type MarketConfig struct {
+	MarketMarginMode          int   `json:"market_margin_mode"`
+	InsuranceFundAccountIndex int64 `json:"insurance_fund_account_index"`
+}
+
+type OrderBookOrders struct {
+	ResultCode
+	TotalAsks int     `json:"total_asks"`
+	Asks      []Order `json:"asks"`
+	TotalBids int     `json:"total_bids"`
+	Bids      []Order `json:"bids"`
+}
+
+type Order struct {
+	OrderIndex          int64  `json:"order_index"`
+	OrderID             string `json:"order_id"`
+	OwnerAccountIndex   int64  `json:"owner_account_index"`
+	InitialBaseAmount   string `json:"initial_base_amount"`
+	RemainingBaseAmount string `json:"remaining_base_amount"`
+	Price               string `json:"price"`
+	OrderExpiry         int64  `json:"order_expiry"`
+}


### PR DESCRIPTION
* Added `AccountsByL1Address` method to `HTTPClient` for querying account information using an L1 address.
* Added `GetTx` method to `HTTPClient` for retrieving transaction details by hash or sequence index.
