### PR TITLE
refactor: remove duplicate package import

### DIFF
--- a/types/txtypes/utils.go
+++ b/types/txtypes/utils.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	gFp5 "github.com/elliottech/poseidon_crypto/field/goldilocks_quintic_extension"
-	gQuint "github.com/elliottech/poseidon_crypto/field/goldilocks_quintic_extension"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -23,7 +22,7 @@ const (
 const SignatureLength = 80
 const L1SignatureLength = 65
 const PubKeyLength = gFp5.Bytes
-const HashLength = gQuint.Bytes
+const HashLength = gFp5.Bytes
 
 func IsValidPubKeyLength(bytes []byte) bool {
 	return len(bytes) == gFp5.Bytes


### PR DESCRIPTION
`github.com/elliottech/poseidon_crypto/field/goldilocks_quintic_extension` was imported twice.
I remove the duplicate import to make the code cleaner and more readable.