### PR TITLE
feat: export Free function for cross-platform memory deallocation

### DIFF
--- a/sharedlib/main.go
+++ b/sharedlib/main.go
@@ -792,4 +792,9 @@ func SignApproveIntegrator(cIntegratorIndex C.longlong, cMaxPerpsTakerFee C.uint
 	return convertTxInfoToResponse(txInfo, err)
 }
 
+//export Free
+func Free(ptr unsafe.Pointer) {
+	C.free(ptr)
+}
+
 func main() {}


### PR DESCRIPTION
## Summary

Exports a `Free(ptr)` function from the CGO shared library that wraps `C.free()`. This is needed so that foreign-language callers (e.g. `lighter-python` via ctypes) can free memory allocated by `C.CString()` using the **same C runtime** that allocated it.

**Why this matters on Windows:** The Go DLL is cross-compiled with MinGW, which may statically link its own CRT or link against a different CRT than what Python finds via `ctypes.util.find_library("c")` (typically `msvcrt.dll`). Calling `free()` from a mismatched CRT on memory allocated by a different CRT's `malloc()` is undefined behavior — crashes, heap corruption, etc. On Linux/macOS there's a single system libc so this problem doesn't manifest.

This is the Go-side half of a two-repo fix. The companion PR in `lighter-python` updates `signer_client.py` to call `signer.Free()` instead of system libc `free()`.

## Review & Testing Checklist for Human

- [ ] After merging, **rebuild the Windows DLL** (`just build-windows-amd64-docker`) and verify the generated `.h` file includes `extern __declspec(dllexport) void Free(void* ptr);`
- [ ] Rebuild all platform binaries (Linux, macOS, Windows) and update them in `lighter-python/lighter/signers/`
- [ ] Test on an actual Windows machine: instantiate `SignerClient`, call a signing function, confirm no crash/heap corruption during `decode_and_free`

### Notes
- The `unsafe` package is already imported in this file, so no new imports were needed.
- This change is inert on its own — the Python SDK must also be updated to call `Free()` instead of libc `free()` for the fix to take effect.
- Linux and macOS are unaffected by the CRT mismatch but will also benefit from using the signer's own `Free()` for correctness.

Requested by: @lavrric