### PR TITLE
Add UpdateAccountConfig transaction type for UTA swap

### DIFF
--- a/client/tx_get.go
+++ b/client/tx_get.go
@@ -251,3 +251,15 @@ func (c *TxClient) GetApproveIntegratorTx(tx *types.ApproveIntegratorTxReq, ops 
 
 	return txInfo, nil
 }
+
+func (c *TxClient) GetUpdateAccountConfigTransaction(tx *types.UpdateAccountConfigTxReq, ops *types.TransactOpts) (*txtypes.L2UpdateAccountConfigTxInfo, error) {
+	ops, err := c.FullFillDefaultOps(ops)
+	if err != nil {
+		return nil, err
+	}
+	txInfo, err := types.ConstructUpdateAccountConfigTx(c.keyManager, c.chainId, tx, ops)
+	if err != nil {
+		return nil, err
+	}
+	return txInfo, nil
+}

--- a/sharedlib/main.go
+++ b/sharedlib/main.go
@@ -804,6 +804,30 @@ func SignApproveIntegrator(cIntegratorIndex C.longlong, cMaxPerpsTakerFee C.uint
 	return convertTxInfoToResponse(txInfo, err)
 }
 
+//export SignUpdateAccountConfig
+func SignUpdateAccountConfig(cAccountTradingMode C.uint8_t, cSkipNonce C.uint8_t, cNonce C.longlong, cApiKeyIndex C.int, cAccountIndex C.longlong) (ret C.SignedTxResponse) {
+	defer func() {
+		if r := recover(); r != nil {
+			ret = signedTxResponsePanic(r)
+		}
+	}()
+
+	c, err := getClient(cApiKeyIndex, cAccountIndex)
+	if err != nil {
+		return signedTxResponseErr(err)
+	}
+
+	accountTradingMode := uint8(cAccountTradingMode)
+
+	tx := &types.UpdateAccountConfigTxReq{
+		AccountTradingMode: accountTradingMode,
+	}
+	ops := getTransactOpts(cSkipNonce, cNonce)
+
+	txInfo, err := c.GetUpdateAccountConfigTransaction(tx, ops)
+	return convertTxInfoToResponse(txInfo, err)
+}
+
 //export Free
 func Free(ptr unsafe.Pointer) {
 	C.free(ptr)

--- a/types/tx_request.go
+++ b/types/tx_request.go
@@ -141,6 +141,10 @@ type UpdateMarginTxReq struct {
 	Direction   uint8
 }
 
+type UpdateAccountConfigTxReq struct {
+	AccountTradingMode uint8
+}
+
 func ConstructAuthToken(key signer.Signer, deadline time.Time, ops *TransactOpts) (string, error) {
 	if ops.FromAccountIndex == nil {
 		return "", fmt.Errorf("missing FromAccountIndex")
@@ -587,6 +591,28 @@ func ConstructUpdateMarginTx(key signer.Signer, lighterChainId uint32, tx *Updat
 	return convertedTx, nil
 }
 
+func ConstructUpdateAccountConfigTx(key signer.Signer, lighterChainId uint32, tx *UpdateAccountConfigTxReq, ops *TransactOpts) (*txtypes.L2UpdateAccountConfigTxInfo, error) {
+	convertedTx := ConvertUpdateAccountConfigTx(tx, ops)
+	err := convertedTx.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	msgHash, err := convertedTx.Hash(lighterChainId)
+	if err != nil {
+		return nil, err
+	}
+
+	signature, err := key.Sign(msgHash, p2.NewPoseidon2())
+	if err != nil {
+		return nil, err
+	}
+
+	convertedTx.SignedHash = ethCommon.Bytes2Hex(msgHash)
+	convertedTx.Sig = signature
+	return convertedTx, nil
+}
+
 func ConvertApproveIntegratorTx(tx *ApproveIntegratorTxReq, ops *TransactOpts) *txtypes.L2ApproveIntegratorTxInfo {
 	return &txtypes.L2ApproveIntegratorTxInfo{
 		IntegratorAccountIndex: tx.IntegratorAccountIndex,
@@ -841,5 +867,16 @@ func ConvertUpdateMarginTx(tx *UpdateMarginTxReq, ops *TransactOpts) *txtypes.L2
 		ExpiredAt:      ops.ExpiredAt,
 		Nonce:          *ops.Nonce,
 		L2TxAttributes: ConstructL2TxAttributes(ops.TxAttributes),
+	}
+}
+
+func ConvertUpdateAccountConfigTx(tx *UpdateAccountConfigTxReq, ops *TransactOpts) *txtypes.L2UpdateAccountConfigTxInfo {
+	return &txtypes.L2UpdateAccountConfigTxInfo{
+		AccountIndex:       *ops.FromAccountIndex,
+		ApiKeyIndex:        *ops.ApiKeyIndex,
+		AccountTradingMode: tx.AccountTradingMode,
+		ExpiredAt:          ops.ExpiredAt,
+		Nonce:              *ops.Nonce,
+		L2TxAttributes:     ConstructL2TxAttributes(ops.TxAttributes),
 	}
 }

--- a/types/txtypes/update_account_config.go
+++ b/types/txtypes/update_account_config.go
@@ -1,0 +1,84 @@
+package txtypes
+
+import (
+	g "github.com/elliottech/poseidon_crypto/field/goldilocks"
+	p2 "github.com/elliottech/poseidon_crypto/hash/poseidon2_goldilocks_plonky2"
+)
+
+type L2UpdateAccountConfigTxInfo struct {
+	AccountIndex int64
+	ApiKeyIndex  uint8
+
+	AccountTradingMode uint8
+
+	ExpiredAt  int64
+	Nonce      int64
+	Sig        []byte
+	SignedHash string `json:"-"`
+
+	L2TxAttributes
+}
+
+func (txInfo *L2UpdateAccountConfigTxInfo) GetTxType() uint8 {
+	return TxTypeL2UpdateAccountConfig
+}
+
+func (txInfo *L2UpdateAccountConfigTxInfo) GetTxInfo() (string, error) {
+	return getTxInfo(txInfo)
+}
+
+func (txInfo *L2UpdateAccountConfigTxInfo) GetTxHash() string {
+	return txInfo.SignedHash
+}
+
+func (txInfo *L2UpdateAccountConfigTxInfo) Validate() error {
+	if err := txInfo.L2TxAttributes.Validate(); err != nil {
+		return err
+	}
+
+	if txInfo.AccountIndex < MinAccountIndex {
+		return ErrFromAccountIndexTooLow
+	}
+	if txInfo.AccountIndex > MaxAccountIndex {
+		return ErrFromAccountIndexTooHigh
+	}
+
+	// ApiKeyIndex
+	if txInfo.ApiKeyIndex < MinApiKeyIndex {
+		return ErrApiKeyIndexTooLow
+	}
+	if txInfo.ApiKeyIndex > MaxApiKeyIndex {
+		return ErrApiKeyIndexTooHigh
+	}
+
+	// AccountTradingMode
+	if txInfo.AccountTradingMode != 0 && txInfo.AccountTradingMode != 1 {
+		return ErrInvalidAccountTradingMode
+	}
+
+	if txInfo.Nonce < MinNonce {
+		return ErrNonceTooLow
+	}
+
+	if txInfo.ExpiredAt < 0 || txInfo.ExpiredAt > MaxTimestamp {
+		return ErrExpiredAtInvalid
+	}
+
+	return nil
+}
+
+func (txInfo *L2UpdateAccountConfigTxInfo) Hash(lighterChainId uint32) (msgHash []byte, err error) {
+	elems := make([]g.GoldilocksField, 0, 7)
+
+	elems = append(elems, g.GoldilocksField(lighterChainId))
+	elems = append(elems, g.GoldilocksField(TxTypeL2UpdateAccountConfig))
+	elems = append(elems, g.GoldilocksField(txInfo.Nonce))
+	elems = append(elems, g.GoldilocksField(txInfo.ExpiredAt))
+
+	elems = append(elems, g.GoldilocksField(txInfo.AccountIndex))
+	elems = append(elems, g.GoldilocksField(txInfo.ApiKeyIndex))
+	elems = append(elems, g.GoldilocksField(txInfo.AccountTradingMode))
+
+	txHash := p2.HashToQuinticExtension(elems)
+	return txInfo.L2TxAttributes.AggregateTxHash(txHash)
+}

--- a/types/txtypes/update_account_config.go
+++ b/types/txtypes/update_account_config.go
@@ -5,6 +5,8 @@ import (
 	p2 "github.com/elliottech/poseidon_crypto/hash/poseidon2_goldilocks_plonky2"
 )
 
+var _ TxInfo = (*L2UpdateAccountConfigTxInfo)(nil)
+
 type L2UpdateAccountConfigTxInfo struct {
 	AccountIndex int64
 	ApiKeyIndex  uint8

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -968,5 +968,37 @@ func main() {
 		})
 	}))
 
+	js.Global().Set("SignUpdateAccountConfig", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		return recoverPanic(func() js.Value {
+			if len(args) < 4 {
+				return js.ValueOf(map[string]interface{}{"error": "SignUpdateAccountConfig expects 4 args: accountTradingMode, nonce, apiKeyIndex, accountIndex"})
+			}
+			c, err := getClient(args)
+			if err != nil {
+				return wrapErr(err)
+			}
+
+			accountTradingMode, err := safeUint8(args[0], 0)
+			if err != nil {
+				return wrapErr(err)
+			}
+			nonce, err := safeInt(args[1], 1)
+			if err != nil {
+				return wrapErr(err)
+			}
+
+			txInfo := &types.UpdateAccountConfigTxReq{
+				AccountTradingMode: accountTradingMode,
+			}
+			ops := new(types.TransactOpts)
+			if nonce != -1 {
+				ops.Nonce = &nonce
+			}
+
+			tx, err := c.GetUpdateAccountConfigTransaction(txInfo, ops)
+			return convertTxInfoToJS(tx, err)
+		})
+	}))
+
 	select {}
 }


### PR DESCRIPTION
## Summary

Adds a new L2 transaction type `UpdateAccountConfig` (`TxTypeL2UpdateAccountConfig = 41`) to enable switching an account's trading mode (e.g., to Unified Trading Account). Changes span all SDK layers:

- **`types/txtypes/update_account_config.go`** — New `L2UpdateAccountConfigTxInfo` struct implementing the `TxInfo` interface (Validate, Hash, GetTxType, GetTxInfo, GetTxHash). Hashes 7 Goldilocks field elements via Poseidon2.
- **`types/tx_request.go`** — New `UpdateAccountConfigTxReq` request struct, `ConstructUpdateAccountConfigTx` (sign flow), and `ConvertUpdateAccountConfigTx` (request→txinfo conversion).
- **`client/tx_get.go`** — New `GetUpdateAccountConfigTransaction` method on `TxClient`.
- **`sharedlib/main.go`** — New `SignUpdateAccountConfig` C-exported function with skipNonce support.
- **`wasm/main.go`** — New `SignUpdateAccountConfig` JS binding (4 args: `accountTradingMode, nonce, apiKeyIndex, accountIndex`).

## Review & Testing Checklist for Human

- [ ] **Hash field ordering must match sequencer** — Verify the Poseidon2 hash element order (`chainId, txType, nonce, expiredAt, accountIndex, apiKeyIndex, accountTradingMode`) matches the sequencer's `UpdateAccountConfig` hash implementation exactly. This cannot be validated from the SDK alone and is the highest-risk item.
- [ ] **AccountTradingMode valid values** — Validation currently only allows `0` and `1`. Confirm these are the only modes the sequencer accepts, and that the semantic meaning (e.g., 0=standard, 1=UTA) is correct.
- [ ] **Error variables in Validate()** — `AccountIndex` field uses `ErrFromAccountIndexTooLow`/`ErrFromAccountIndexTooHigh` (error message says "FromAccountIndex"). Other tx types with a plain `AccountIndex` field use `ErrAccountIndexTooLow`/`ErrAccountIndexTooHigh`. Verify if this is intentional or should be switched for consistency.
- [ ] **End-to-end signing test** — No unit tests are included. Consider signing a test transaction and verifying the output against a known-good hash from the sequencer or another SDK implementation.

### Notes
- The WASM binding uses `safeUint8`/`safeInt` for argument parsing, which is safer than some older bindings that cast directly.
- The `UpdateAccountConfigTxReq` struct currently only contains `AccountTradingMode`. If more config fields are planned, the struct is ready to be extended.

Link to Devin session: https://app.devin.ai/sessions/199100f8758a4fd29fc8c4e053a2a3fd
Requested by: @mihaimarcu2004