### PR TITLE
fix(wasm): restore build after integrator fields moved to L2TxAttributes

### DIFF
--- a/wasm/main.go
+++ b/wasm/main.go
@@ -327,21 +327,26 @@ func main() {
 			}
 
 			txInfo := &types.CreateOrderTxReq{
-				MarketIndex:            int16(marketIndex),
-				ClientOrderIndex:       clientOrderIndex,
-				BaseAmount:             baseAmount,
-				Price:                  price,
-				IsAsk:                  isAsk,
-				Type:                   orderType,
-				TimeInForce:            timeInForce,
-				ReduceOnly:             reduceOnly,
-				TriggerPrice:           triggerPrice,
-				OrderExpiry:            orderExpiry,
-				IntegratorAccountIndex: int(integratorAccountIndex),
-				IntegratorTakerFee:     int(integratorTakerFee),
-				IntegratorMakerFee:     int(integratorMakerFee),
+				MarketIndex:      int16(marketIndex),
+				ClientOrderIndex: clientOrderIndex,
+				BaseAmount:       baseAmount,
+				Price:            price,
+				IsAsk:            isAsk,
+				Type:             orderType,
+				TimeInForce:      timeInForce,
+				ReduceOnly:       reduceOnly,
+				TriggerPrice:     triggerPrice,
+				OrderExpiry:      orderExpiry,
 			}
-			ops := new(types.TransactOpts)
+			integratorTakerFeeU32 := uint32(integratorTakerFee)
+			integratorMakerFeeU32 := uint32(integratorMakerFee)
+			ops := &types.TransactOpts{
+				TxAttributes: &types.L2TxAttributes{
+					IntegratorAccountIndex: &integratorAccountIndex,
+					IntegratorTakerFee:     &integratorTakerFeeU32,
+					IntegratorMakerFee:     &integratorMakerFeeU32,
+				},
+			}
 			if nonce != -1 {
 				ops.Nonce = &nonce
 			}
@@ -605,22 +610,25 @@ func main() {
 			baseAmount := int64(args[2].Int())
 			price := uint32(args[3].Int())
 			triggerPrice := uint32(args[4].Int())
-			integratorAccountIndex := int(args[5].Int())
-			integratorTakerFee := int(args[6].Int())
-			integratorMakerFee := int(args[7].Int())
+			integratorAccountIndex := int64(args[5].Int())
+			integratorTakerFee := uint32(args[6].Int())
+			integratorMakerFee := uint32(args[7].Int())
 			nonce := int64(args[8].Int())
 
 			txInfo := &types.ModifyOrderTxReq{
-				MarketIndex:            marketIndex,
-				Index:                  index,
-				BaseAmount:             baseAmount,
-				Price:                  price,
-				TriggerPrice:           triggerPrice,
-				IntegratorAccountIndex: integratorAccountIndex,
-				IntegratorTakerFee:     integratorTakerFee,
-				IntegratorMakerFee:     integratorMakerFee,
+				MarketIndex:  marketIndex,
+				Index:        index,
+				BaseAmount:   baseAmount,
+				Price:        price,
+				TriggerPrice: triggerPrice,
 			}
-			ops := new(types.TransactOpts)
+			ops := &types.TransactOpts{
+				TxAttributes: &types.L2TxAttributes{
+					IntegratorAccountIndex: &integratorAccountIndex,
+					IntegratorTakerFee:     &integratorTakerFee,
+					IntegratorMakerFee:     &integratorMakerFee,
+				},
+			}
 			if nonce != -1 {
 				ops.Nonce = &nonce
 			}
@@ -888,6 +896,9 @@ func main() {
 			length := ordersArg.Length()
 			orders := make([]*types.CreateOrderTxReq, length)
 
+			var integratorAccountIndex int64
+			var integratorTakerFee, integratorMakerFee uint32
+
 			for i := 0; i < length; i++ {
 				orderObj := ordersArg.Index(i)
 				if orderObj.Type() != js.TypeObject {
@@ -900,19 +911,22 @@ func main() {
 				}
 
 				orders[i] = &types.CreateOrderTxReq{
-					MarketIndex:            int16(orderObj.Get("MarketIndex").Int()),
-					ClientOrderIndex:       int64(orderObj.Get("ClientOrderIndex").Int()),
-					BaseAmount:             int64(orderObj.Get("BaseAmount").Int()),
-					Price:                  uint32(orderObj.Get("Price").Int()),
-					IsAsk:                  uint8(orderObj.Get("IsAsk").Int()),
-					Type:                   uint8(orderObj.Get("Type").Int()),
-					TimeInForce:            uint8(orderObj.Get("TimeInForce").Int()),
-					ReduceOnly:             uint8(orderObj.Get("ReduceOnly").Int()),
-					TriggerPrice:           uint32(orderObj.Get("TriggerPrice").Int()),
-					OrderExpiry:            orderExpiry,
-					IntegratorAccountIndex: int(orderObj.Get("IntegratorAccountIndex").Int()),
-					IntegratorTakerFee:     int(orderObj.Get("IntegratorTakerFee").Int()),
-					IntegratorMakerFee:     int(orderObj.Get("IntegratorMakerFee").Int()),
+					MarketIndex:      int16(orderObj.Get("MarketIndex").Int()),
+					ClientOrderIndex: int64(orderObj.Get("ClientOrderIndex").Int()),
+					BaseAmount:       int64(orderObj.Get("BaseAmount").Int()),
+					Price:            uint32(orderObj.Get("Price").Int()),
+					IsAsk:            uint8(orderObj.Get("IsAsk").Int()),
+					Type:             uint8(orderObj.Get("Type").Int()),
+					TimeInForce:      uint8(orderObj.Get("TimeInForce").Int()),
+					ReduceOnly:       uint8(orderObj.Get("ReduceOnly").Int()),
+					TriggerPrice:     uint32(orderObj.Get("TriggerPrice").Int()),
+					OrderExpiry:      orderExpiry,
+				}
+
+				if i == 0 {
+					integratorAccountIndex = int64(orderObj.Get("IntegratorAccountIndex").Int())
+					integratorTakerFee = uint32(orderObj.Get("IntegratorTakerFee").Int())
+					integratorMakerFee = uint32(orderObj.Get("IntegratorMakerFee").Int())
 				}
 			}
 
@@ -922,7 +936,13 @@ func main() {
 				GroupingType: groupingType,
 				Orders:       orders,
 			}
-			ops := new(types.TransactOpts)
+			ops := &types.TransactOpts{
+				TxAttributes: &types.L2TxAttributes{
+					IntegratorAccountIndex: &integratorAccountIndex,
+					IntegratorTakerFee:     &integratorTakerFee,
+					IntegratorMakerFee:     &integratorMakerFee,
+				},
+			}
 			if nonce != -1 {
 				ops.Nonce = &nonce
 			}


### PR DESCRIPTION
## Summary

The WASM target (`wasm/main.go`) has been broken on `main` since #57 (`dd454f9` "Skip nonce"). That PR moved `IntegratorAccountIndex`, `IntegratorTakerFee`, and `IntegratorMakerFee` off the per-request structs (`CreateOrderTxReq`, `ModifyOrderTxReq`) and onto the new `L2TxAttributes` envelope carried by `TransactOpts`. `sharedlib/main.go` was updated in the same PR; `wasm/main.go` was not.

Result: running the project's own `just build-wasm` recipe fails with 9 compile errors:

```
wasm/main.go:340:5: unknown field IntegratorAccountIndex in struct literal of type "github.com/elliottech/lighter-go/types".CreateOrderTxReq
wasm/main.go:341:5: unknown field IntegratorTakerFee in struct literal of type "github.com/elliottech/lighter-go/types".CreateOrderTxReq
wasm/main.go:342:5: unknown field IntegratorMakerFee in struct literal of type "github.com/elliottech/lighter-go/types".CreateOrderTxReq
wasm/main.go:619:5: unknown field IntegratorAccountIndex in struct literal of type "github.com/elliottech/lighter-go/types".ModifyOrderTxReq
wasm/main.go:620:5: unknown field IntegratorTakerFee in struct literal of type "github.com/elliottech/lighter-go/types".ModifyOrderTxReq
wasm/main.go:621:5: unknown field IntegratorMakerFee in struct literal of type "github.com/elliottech/lighter-go/types".ModifyOrderTxReq
wasm/main.go:913:6: unknown field IntegratorAccountIndex in struct literal of type "github.com/elliottech/lighter-go/types".CreateOrderTxReq
wasm/main.go:914:6: unknown field IntegratorTakerFee in struct literal of type "github.com/elliottech/lighter-go/types".CreateOrderTxReq
wasm/main.go:915:6: unknown field IntegratorMakerFee in struct literal of type "github.com/elliottech/lighter-go/types".CreateOrderTxReq
```

Bisection confirmed #57 as the exact regression commit (last good: `c3f35bd` / #56).

## Fix

Minimal change that makes the WASM build match the new `L2TxAttributes` contract. The three fields are now populated via `ops.TxAttributes` instead of the request struct. Applied in all three affected endpoints:

- `SignCreateOrder`
- `SignModifyOrder`
- `SignCreateGroupedOrders`

### JS ABI is preserved

No argument count or position changes. Existing JS callers keep working:

- `SignCreateOrder` — still 16 args, integrator fields still at indices 10/11/12.
- `SignModifyOrder` — still 11 args, integrator fields still at 5/6/7.
- `SignCreateGroupedOrders` — still 5 args. Integrator config is read from the **first order** in the array and hoisted to the tx-level `L2TxAttributes` (the new model has one integrator config per tx, not per order, so this matches the intent of the previous per-order fields when all orders shared the same integrator).

### What this PR does *not* include

Out of scope — happy to do a follow-up PR if desired:

- **`SkipNonce` plumbing.** The new `L2TxAttributes.SkipNonce` field is wired in `sharedlib` but not in WASM. This PR does not add it; all three endpoints leave `SkipNonce` unset, preserving pre-#57 behavior.

## Verification

```
$ just build-wasm
go mod vendor
GOOS=js GOARCH=wasm go build -trimpath -o ./build/lighter-signer.wasm ./wasm/
$ ls -lh build/lighter-signer.wasm
-rwxr-xr-x  1  staff  14M  build/lighter-signer.wasm
```

`go vet` under `GOOS=js GOARCH=wasm` is clean. No runtime testing was done (the repo has no JS-side smoke test).

## Test plan

- [x] `just build-wasm` succeeds on this branch
- [x] `just build-wasm` fails identically on `main` without this patch
- [x] `go vet` clean under `GOOS=js GOARCH=wasm`
- [ ] Browser-side smoke test — out of scope; no test harness exists in repo