### PR TITLE
fix(wasm): add skipNonce arg to SignUpdateAccountConfig

### DIFF
--- a/wasm/main.go
+++ b/wasm/main.go
@@ -1031,8 +1031,8 @@ func main() {
 
 	js.Global().Set("SignUpdateAccountConfig", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 		return recoverPanic(func() js.Value {
-			if len(args) < 4 {
-				return js.ValueOf(map[string]interface{}{"error": "SignUpdateAccountConfig expects 4 args: accountTradingMode, nonce, apiKeyIndex, accountIndex"})
+			if len(args) < 5 {
+				return js.ValueOf(map[string]interface{}{"error": "SignUpdateAccountConfig expects 5 args: accountTradingMode, skipNonce, nonce, apiKeyIndex, accountIndex"})
 			}
 			c, err := getClient(args)
 			if err != nil {
@@ -1043,7 +1043,11 @@ func main() {
 			if err != nil {
 				return wrapErr(err)
 			}
-			nonce, err := safeInt(args[1], 1)
+			skipNonce, err := safeUint8(args[1], 1)
+			if err != nil {
+				return wrapErr(err)
+			}
+			nonce, err := safeInt(args[2], 2)
 			if err != nil {
 				return wrapErr(err)
 			}
@@ -1052,6 +1056,7 @@ func main() {
 				AccountTradingMode: accountTradingMode,
 			}
 			ops := new(types.TransactOpts)
+			ops.TxAttributes = txAttributesWithSkipNonce(skipNonce)
 			if nonce != -1 {
 				ops.Nonce = &nonce
 			}


### PR DESCRIPTION
## Summary

#58 added `skipNonce` support to every WASM `Sign*` endpoint **except** `SignUpdateAccountConfig`. This was likely because `SignUpdateAccountConfig` was added in #61 while #58 was in flight, so the two PRs didn't reconcile.

As a result, WASM is now inconsistent with sharedlib for this one tx type:

| | sharedlib (`main.go:808`) | wasm (before this PR) |
|---|---|---|
| Takes `skipNonce` arg? | ✅ `cSkipNonce C.uint8_t` | ❌ |
| Passes it via `TxAttributes`? | ✅ via `getTransactOpts` | ❌ |

Every other `Sign*` endpoint in wasm now uses the `txAttributesWithSkipNonce` helper introduced in #58; this PR applies the same pattern to `SignUpdateAccountConfig`.

## Changes

Before:
```
SignUpdateAccountConfig(accountTradingMode, nonce, apiKeyIndex, accountIndex)
```

After:
```
SignUpdateAccountConfig(accountTradingMode, skipNonce, nonce, apiKeyIndex, accountIndex)
```

**This is a breaking change for JS callers of `SignUpdateAccountConfig`** — but so were the changes in #58 for every other `Sign*` endpoint, so this is consistent with the migration already in progress.

## Verification

```
$ just build-wasm
go mod vendor
GOOS=js GOARCH=wasm go build -trimpath -o ./build/lighter-signer.wasm ./wasm/
$ GOOS=js GOARCH=wasm go vet ./wasm/...
(clean)
```

## Test plan

- [x] `just build-wasm` succeeds
- [x] `go vet` clean under `GOOS=js GOARCH=wasm`
- [x] Pattern matches what #58 did for every other endpoint
- [x] Matches sharedlib's `SignUpdateAccountConfig` shape (`sharedlib/main.go:808`)