### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/client/http/requests.go
+++ b/client/http/requests.go
@@ -20,7 +20,7 @@ func (c *client) parseResultStatus(respBody []byte) error {
 	return nil
 }
 
-func (c *client) getAndParseL2HTTPResponse(path string, params map[string]any, result interface{}) error {
+func (c *client) getAndParseL2HTTPResponse(path string, params map[string]any, result any) error {
 	u, err := url.Parse(c.endpoint)
 	if err != nil {
 		return err

--- a/types/txtypes/utils.go
+++ b/types/txtypes/utils.go
@@ -40,7 +40,7 @@ func IsZeroByteSlice(bytes []byte) bool {
 	return true
 }
 
-func getTxInfo(tx interface{}) (string, error) {
+func getTxInfo(tx any) (string, error) {
 	txInfoBytes, err := json.Marshal(tx)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.
 
As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.