### PR TITLE
UpdateAccountAssetConfig

### DIFF
--- a/client/tx_get.go
+++ b/client/tx_get.go
@@ -263,3 +263,15 @@ func (c *TxClient) GetUpdateAccountConfigTransaction(tx *types.UpdateAccountConf
 	}
 	return txInfo, nil
 }
+
+func (c *TxClient) GetUpdateAccountAssetConfigTransaction(tx *types.UpdateAccountAssetConfigTxReq, ops *types.TransactOpts) (*txtypes.L2UpdateAccountAssetConfigTxInfo, error) {
+	ops, err := c.FullFillDefaultOps(ops)
+	if err != nil {
+		return nil, err
+	}
+	txInfo, err := types.ConstructUpdateAccountAssetConfigTx(c.keyManager, c.chainId, tx, ops)
+	if err != nil {
+		return nil, err
+	}
+	return txInfo, nil
+}

--- a/sharedlib/main.go
+++ b/sharedlib/main.go
@@ -828,6 +828,29 @@ func SignUpdateAccountConfig(cAccountTradingMode C.uint8_t, cSkipNonce C.uint8_t
 	return convertTxInfoToResponse(txInfo, err)
 }
 
+//export SignUpdateAccountAssetConfig
+func SignUpdateAccountAssetConfig(cAssetIndex C.int16_t, cAssetMarginMode C.uint8_t, cSkipNonce C.uint8_t, cNonce C.longlong, cApiKeyIndex C.int, cAccountIndex C.longlong) (ret C.SignedTxResponse) {
+	defer func() {
+		if r := recover(); r != nil {
+			ret = signedTxResponsePanic(r)
+		}
+	}()
+
+	c, err := getClient(cApiKeyIndex, cAccountIndex)
+	if err != nil {
+		return signedTxResponseErr(err)
+	}
+
+	tx := &types.UpdateAccountAssetConfigTxReq{
+		AssetIndex:      int16(cAssetIndex),
+		AssetMarginMode: uint8(cAssetMarginMode),
+	}
+	ops := getTransactOpts(cSkipNonce, cNonce)
+
+	txInfo, err := c.GetUpdateAccountAssetConfigTransaction(tx, ops)
+	return convertTxInfoToResponse(txInfo, err)
+}
+
 //export Free
 func Free(ptr unsafe.Pointer) {
 	C.free(ptr)

--- a/types/tx_request.go
+++ b/types/tx_request.go
@@ -145,6 +145,11 @@ type UpdateAccountConfigTxReq struct {
 	AccountTradingMode uint8
 }
 
+type UpdateAccountAssetConfigTxReq struct {
+	AssetIndex      int16
+	AssetMarginMode uint8
+}
+
 func ConstructAuthToken(key signer.Signer, deadline time.Time, ops *TransactOpts) (string, error) {
 	if ops.FromAccountIndex == nil {
 		return "", fmt.Errorf("missing FromAccountIndex")
@@ -613,6 +618,28 @@ func ConstructUpdateAccountConfigTx(key signer.Signer, lighterChainId uint32, tx
 	return convertedTx, nil
 }
 
+func ConstructUpdateAccountAssetConfigTx(key signer.Signer, lighterChainId uint32, tx *UpdateAccountAssetConfigTxReq, ops *TransactOpts) (*txtypes.L2UpdateAccountAssetConfigTxInfo, error) {
+	convertedTx := ConvertUpdateAccountAssetConfigTx(tx, ops)
+	err := convertedTx.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	msgHash, err := convertedTx.Hash(lighterChainId)
+	if err != nil {
+		return nil, err
+	}
+
+	signature, err := key.Sign(msgHash, p2.NewPoseidon2())
+	if err != nil {
+		return nil, err
+	}
+
+	convertedTx.SignedHash = ethCommon.Bytes2Hex(msgHash)
+	convertedTx.Sig = signature
+	return convertedTx, nil
+}
+
 func ConvertApproveIntegratorTx(tx *ApproveIntegratorTxReq, ops *TransactOpts) *txtypes.L2ApproveIntegratorTxInfo {
 	return &txtypes.L2ApproveIntegratorTxInfo{
 		IntegratorAccountIndex: tx.IntegratorAccountIndex,
@@ -878,5 +905,17 @@ func ConvertUpdateAccountConfigTx(tx *UpdateAccountConfigTxReq, ops *TransactOpt
 		ExpiredAt:          ops.ExpiredAt,
 		Nonce:              *ops.Nonce,
 		L2TxAttributes:     ConstructL2TxAttributes(ops.TxAttributes),
+	}
+}
+
+func ConvertUpdateAccountAssetConfigTx(tx *UpdateAccountAssetConfigTxReq, ops *TransactOpts) *txtypes.L2UpdateAccountAssetConfigTxInfo {
+	return &txtypes.L2UpdateAccountAssetConfigTxInfo{
+		AccountIndex:    *ops.FromAccountIndex,
+		ApiKeyIndex:     *ops.ApiKeyIndex,
+		AssetIndex:      tx.AssetIndex,
+		AssetMarginMode: tx.AssetMarginMode,
+		ExpiredAt:       ops.ExpiredAt,
+		Nonce:           *ops.Nonce,
+		L2TxAttributes:  ConstructL2TxAttributes(ops.TxAttributes),
 	}
 }

--- a/types/txtypes/constants.go
+++ b/types/txtypes/constants.go
@@ -54,9 +54,10 @@ const (
 	TxTypeInternalLiquidatePosition = 26
 	TxTypeInternalCreateOrder       = 27
 
-	TxTypeL2CreateGroupedOrders = 28
-	TxTypeL2UpdateMargin        = 29
-	TxTypeL2UpdateAccountConfig = 41
+	TxTypeL2CreateGroupedOrders      = 28
+	TxTypeL2UpdateMargin             = 29
+	TxTypeL2UpdateAccountConfig      = 41
+	TxTypeL2UpdateAccountAssetConfig = 42
 
 	TxTypeL1BurnShares    = 30
 	TxTypeL1RegisterAsset = 31
@@ -115,6 +116,11 @@ const (
 	AssetMarginMode_Disabled = 0
 	AssetMarginMode_Enabled  = 1
 	AssetMarginMode_Max      = AssetMarginMode_Enabled
+)
+
+const (
+	AccountAssetMarginMode_MarginDisabled = 0 // means account is not using this asset as margin
+	AccountAssetMarginMode_MarginEnabled  = 1 // means account is using this asset as margin
 )
 
 // Asset Route Type

--- a/types/txtypes/errors.go
+++ b/types/txtypes/errors.go
@@ -82,6 +82,7 @@ var (
 	ErrInvalidStrategyIndex                         = fmt.Errorf("StrategyIndex is not valid")
 	ErrAccountIndexMustBtInsuranceFundOperator      = fmt.Errorf("AccountIndex must be the insurance fund operator account index %d", InsuranceFundOperatorAccountIndex)
 	ErrInvalidAccountTradingMode                    = fmt.Errorf("AccountTradingMode is invalid")
+	ErrInvalidAssetMarginMode                       = fmt.Errorf("AssetMarginMode is invalid")
 	ErrTooManyAttributes                            = fmt.Errorf("Too many attributes, should not be larger than %d", NbAttributesPerTx)
 	ErrInvalidAttributeType                         = fmt.Errorf("Attribute type is invalid")
 	ErrAttributeValueOutOfRange                     = fmt.Errorf("Attribute value is out of range")

--- a/types/txtypes/update_account_asset_config.go
+++ b/types/txtypes/update_account_asset_config.go
@@ -1,0 +1,96 @@
+package txtypes
+
+import (
+	g "github.com/elliottech/poseidon_crypto/field/goldilocks"
+	p2 "github.com/elliottech/poseidon_crypto/hash/poseidon2_goldilocks_plonky2"
+)
+
+var _ (TxInfo) = (*L2UpdateAccountAssetConfigTxInfo)(nil)
+
+type L2UpdateAccountAssetConfigTxInfo struct {
+	AccountIndex int64
+	ApiKeyIndex  uint8
+
+	AssetIndex      int16
+	AssetMarginMode uint8
+
+	ExpiredAt  int64
+	Nonce      int64
+	Sig        []byte
+	SignedHash string `json:"-"`
+
+	L2TxAttributes
+}
+
+func (txInfo *L2UpdateAccountAssetConfigTxInfo) GetTxType() uint8 {
+	return TxTypeL2UpdateAccountAssetConfig
+}
+
+func (txInfo *L2UpdateAccountAssetConfigTxInfo) GetTxInfo() (string, error) {
+	return getTxInfo(txInfo)
+}
+
+func (txInfo *L2UpdateAccountAssetConfigTxInfo) GetTxHash() string {
+	return txInfo.SignedHash
+}
+
+func (txInfo *L2UpdateAccountAssetConfigTxInfo) Validate() error {
+	if err := txInfo.L2TxAttributes.Validate(); err != nil {
+		return err
+	}
+
+	if txInfo.AccountIndex < MinAccountIndex {
+		return ErrFromAccountIndexTooLow
+	}
+	if txInfo.AccountIndex > MaxAccountIndex {
+		return ErrFromAccountIndexTooHigh
+	}
+
+	// ApiKeyIndex
+	if txInfo.ApiKeyIndex < MinApiKeyIndex {
+		return ErrApiKeyIndexTooLow
+	}
+	if txInfo.ApiKeyIndex > MaxApiKeyIndex {
+		return ErrApiKeyIndexTooHigh
+	}
+
+	// AssetIndex
+	if txInfo.AssetIndex < MinAssetIndex {
+		return ErrAssetIndexTooLow
+	}
+	if txInfo.AssetIndex > MaxAssetIndex {
+		return ErrAssetIndexTooHigh
+	}
+
+	// AssetMarginMode
+	if txInfo.AssetMarginMode != AccountAssetMarginMode_MarginDisabled && txInfo.AssetMarginMode != AccountAssetMarginMode_MarginEnabled {
+		return ErrInvalidMarginMode
+	}
+
+	if txInfo.Nonce < MinNonce {
+		return ErrNonceTooLow
+	}
+
+	if txInfo.ExpiredAt < 0 || txInfo.ExpiredAt > MaxTimestamp {
+		return ErrExpiredAtInvalid
+	}
+
+	return nil
+}
+
+func (txInfo *L2UpdateAccountAssetConfigTxInfo) Hash(lighterChainId uint32) (msgHash []byte, err error) {
+	elems := make([]g.GoldilocksField, 0, 8)
+
+	elems = append(elems, g.GoldilocksField(lighterChainId))
+	elems = append(elems, g.GoldilocksField(TxTypeL2UpdateAccountAssetConfig))
+	elems = append(elems, g.GoldilocksField(txInfo.Nonce))
+	elems = append(elems, g.GoldilocksField(txInfo.ExpiredAt))
+
+	elems = append(elems, g.GoldilocksField(txInfo.AccountIndex))
+	elems = append(elems, g.GoldilocksField(txInfo.ApiKeyIndex))
+	elems = append(elems, g.GoldilocksField(txInfo.AssetIndex))
+	elems = append(elems, g.GoldilocksField(txInfo.AssetMarginMode))
+
+	txHash := p2.HashToQuinticExtension(elems)
+	return txInfo.L2TxAttributes.AggregateTxHash(txHash)
+}

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -1066,5 +1066,47 @@ func main() {
 		})
 	}))
 
+	js.Global().Set("SignUpdateAccountAssetConfig", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		return recoverPanic(func() js.Value {
+			if len(args) < 6 {
+				return js.ValueOf(map[string]interface{}{"error": "SignUpdateAccountAssetConfig expects 6 args: assetIndex, assetMarginMode, skipNonce, nonce, apiKeyIndex, accountIndex"})
+			}
+			c, err := getClient(args)
+			if err != nil {
+				return wrapErr(err)
+			}
+
+			assetIndexInt, err := safeInt(args[0], 0)
+			if err != nil {
+				return wrapErr(err)
+			}
+			assetMarginMode, err := safeUint8(args[1], 1)
+			if err != nil {
+				return wrapErr(err)
+			}
+			skipNonce, err := safeUint8(args[2], 2)
+			if err != nil {
+				return wrapErr(err)
+			}
+			nonce, err := safeInt(args[3], 3)
+			if err != nil {
+				return wrapErr(err)
+			}
+
+			txInfo := &types.UpdateAccountAssetConfigTxReq{
+				AssetIndex:      int16(assetIndexInt),
+				AssetMarginMode: assetMarginMode,
+			}
+			ops := new(types.TransactOpts)
+			ops.TxAttributes = txAttributesWithSkipNonce(skipNonce)
+			if nonce != -1 {
+				ops.Nonce = &nonce
+			}
+
+			tx, err := c.GetUpdateAccountAssetConfigTransaction(txInfo, ops)
+			return convertTxInfoToJS(tx, err)
+		})
+	}))
+
 	select {}
 }


### PR DESCRIPTION
## Summary
Adds a new L2 transaction type, `UpdateAccountAssetConfig` (tx type `42`), which lets an account toggle whether a given asset is used as margin.

Changes:
- `types/txtypes/update_account_asset_config.go`: new `L2UpdateAccountAssetConfigTxInfo` implementing `TxInfo` — fields `AccountIndex`, `ApiKeyIndex`, `AssetIndex`, `AssetMarginMode`, `ExpiredAt`, `Nonce`, plus validation and Poseidon2 hashing over the standard tx header + asset fields.
- `types/txtypes/constants.go`: new `TxTypeL2UpdateAccountAssetConfig = 42`, plus `AccountAssetMarginMode_MarginDisabled = 0` / `AccountAssetMarginMode_MarginEnabled = 1`.
- `types/txtypes/errors.go`: new `ErrInvalidAssetMarginMode`.
- `types/tx_request.go`: new `UpdateAccountAssetConfigTxReq` request struct and `ConstructUpdateAccountAssetConfigTx` / `ConvertUpdateAccountAssetConfigTx` helpers that build, validate, hash, and sign the tx.
- `client/tx_get.go`: new `TxClient.GetUpdateAccountAssetConfigTransaction` entry point.
- `sharedlib/main.go`: exports `SignUpdateAccountAssetConfig` C binding (consumed by the Python SDK).
- `wasm/main.go`: exports `SignUpdateAccountAssetConfig` JS binding with 6 args (`assetIndex, assetMarginMode, skipNonce, nonce, apiKeyIndex, accountIndex`).
