### PR TITLE
feat: expose self-trade attributes in sharedlib and wasm bindings

### DIFF
--- a/examples/cpp/example.cpp
+++ b/examples/cpp/example.cpp
@@ -72,6 +72,8 @@ void run_example(int apiKeyIndex) {
             /* cIntegratorAccountIndex */ 0,
             /* cIntegratorTakerFee */ 0,
             /* cIntegratorMakerFee */ 0,
+            /* cSelfTradeBehaviorMode */ 0,
+            /* cSelfTradeEqualityMode */ 0,
             /* cSkipNonce */ 0,
             nonce, apiKeyIndex, accountIndex);
         nonce += 1;

--- a/examples/java/src/main/java/Example.java
+++ b/examples/java/src/main/java/Example.java
@@ -81,6 +81,8 @@ public class Example {
                 /* integratorAccountIndex */  0L,
                 /* integratorTakerFee */      0,
                 /* integratorMakerFee */      0,
+                /* selfTradeBehaviorMode */   (byte) 0,
+                /* selfTradeEqualityMode */   (byte) 0,
                 /* skipNonce */ (byte) 0,
                 nonce,
                 apiKeyIndex,

--- a/examples/java/src/main/java/LighterLib.java
+++ b/examples/java/src/main/java/LighterLib.java
@@ -132,11 +132,13 @@ public class LighterLib {
                 int price, int isAsk, int orderType, int timeInForce,
                 int reduceOnly, int triggerPrice, long orderExpiry,
                 long integratorAccountIndex, int integratorTakerFee, int integratorMakerFee,
+                byte selfTradeBehaviorMode, byte selfTradeEqualityMode,
                 byte skipNonce, long nonce, int apiKeyIndex, long accountIndex);
 
         SignedTxResponse.ByValue SignCreateGroupedOrders(
                 byte groupingType, CreateOrderTxReq orders, int len,
                 long integratorAccountIndex, int integratorTakerFee, int integratorMakerFee,
+                byte selfTradeBehaviorMode, byte selfTradeEqualityMode,
                 byte skipNonce, long nonce, int apiKeyIndex, long accountIndex);
 
         SignedTxResponse.ByValue SignCancelOrder(int marketIndex, long orderIndex,
@@ -151,12 +153,14 @@ public class LighterLib {
                                                       int apiKeyIndex, long accountIndex);
 
         SignedTxResponse.ByValue SignCancelAllOrders(int timeInForce, long time,
+                                                     int cancelAllMarketIndex,
                                                      byte skipNonce, long nonce,
                                                      int apiKeyIndex, long accountIndex);
 
         SignedTxResponse.ByValue SignModifyOrder(
                 int marketIndex, long index, long baseAmount, long price, long triggerPrice,
                 long integratorAccountIndex, int integratorTakerFee, int integratorMakerFee,
+                byte selfTradeBehaviorMode, byte selfTradeEqualityMode,
                 byte skipNonce, long nonce, int apiKeyIndex, long accountIndex);
 
         SignedTxResponse.ByValue SignTransfer(

--- a/examples/rust/src/lib.rs
+++ b/examples/rust/src/lib.rs
@@ -267,6 +267,8 @@ impl LighterLib {
         integrator_account_index: i64,
         integrator_taker_fee: i32,
         integrator_maker_fee: i32,
+        self_trade_behavior_mode: u8,
+        self_trade_equality_mode: u8,
         skip_nonce: u8,
         nonce: i64,
         api_key_index: i32,
@@ -276,7 +278,7 @@ impl LighterLib {
             let f: Symbol<
                 unsafe extern "C" fn(
                     i32, i64, i64, i32, i32, i32, i32, i32, i32, i64,
-                    i64, i32, i32, u8, i64, i32, i64,
+                    i64, i32, i32, u8, u8, u8, i64, i32, i64,
                 ) -> RawSignedTxResponse,
             > = self.lib.get(b"SignCreateOrder\0").unwrap();
             raw_to_signed_tx(f(
@@ -293,6 +295,8 @@ impl LighterLib {
                 integrator_account_index,
                 integrator_taker_fee,
                 integrator_maker_fee,
+                self_trade_behavior_mode,
+                self_trade_equality_mode,
                 skip_nonce,
                 nonce,
                 api_key_index,
@@ -309,6 +313,8 @@ impl LighterLib {
         integrator_account_index: i64,
         integrator_taker_fee: i32,
         integrator_maker_fee: i32,
+        self_trade_behavior_mode: u8,
+        self_trade_equality_mode: u8,
         skip_nonce: u8,
         nonce: i64,
         api_key_index: i32,
@@ -318,7 +324,7 @@ impl LighterLib {
             let f: Symbol<
                 unsafe extern "C" fn(
                     u8, *const CreateOrderTxReq, i32,
-                    i64, i32, i32, u8, i64, i32, i64,
+                    i64, i32, i32, u8, u8, u8, i64, i32, i64,
                 ) -> RawSignedTxResponse,
             > = self.lib.get(b"SignCreateGroupedOrders\0").unwrap();
             raw_to_signed_tx(f(
@@ -328,6 +334,8 @@ impl LighterLib {
                 integrator_account_index,
                 integrator_taker_fee,
                 integrator_maker_fee,
+                self_trade_behavior_mode,
+                self_trade_equality_mode,
                 skip_nonce,
                 nonce,
                 api_key_index,
@@ -399,6 +407,7 @@ impl LighterLib {
         &self,
         time_in_force: i32,
         time: i64,
+        cancel_all_market_index: i32,
         skip_nonce: u8,
         nonce: i64,
         api_key_index: i32,
@@ -406,10 +415,10 @@ impl LighterLib {
     ) -> SignedTxResponse {
         unsafe {
             let f: Symbol<
-                unsafe extern "C" fn(i32, i64, u8, i64, i32, i64) -> RawSignedTxResponse,
+                unsafe extern "C" fn(i32, i64, i32, u8, i64, i32, i64) -> RawSignedTxResponse,
             > = self.lib.get(b"SignCancelAllOrders\0").unwrap();
             raw_to_signed_tx(f(
-                time_in_force, time, skip_nonce, nonce, api_key_index, account_index,
+                time_in_force, time, cancel_all_market_index, skip_nonce, nonce, api_key_index, account_index,
             ), self.free_fn)
         }
     }
@@ -425,6 +434,8 @@ impl LighterLib {
         integrator_account_index: i64,
         integrator_taker_fee: i32,
         integrator_maker_fee: i32,
+        self_trade_behavior_mode: u8,
+        self_trade_equality_mode: u8,
         skip_nonce: u8,
         nonce: i64,
         api_key_index: i32,
@@ -434,12 +445,13 @@ impl LighterLib {
             let f: Symbol<
                 unsafe extern "C" fn(
                     i32, i64, i64, i64, i64,
-                    i64, i32, i32, u8, i64, i32, i64,
+                    i64, i32, i32, u8, u8, u8, i64, i32, i64,
                 ) -> RawSignedTxResponse,
             > = self.lib.get(b"SignModifyOrder\0").unwrap();
             raw_to_signed_tx(f(
                 market_index, index, base_amount, price, trigger_price,
                 integrator_account_index, integrator_taker_fee, integrator_maker_fee,
+                self_trade_behavior_mode, self_trade_equality_mode,
                 skip_nonce, nonce, api_key_index, account_index,
             ), self.free_fn)
         }

--- a/examples/rust/src/main.rs
+++ b/examples/rust/src/main.rs
@@ -75,6 +75,8 @@ fn run_example(lib: &LighterLib, api_key_index: i32) {
             0,               // integrator_account_index
             0,               // integrator_taker_fee
             0,               // integrator_maker_fee
+            0,               // self_trade_behavior_mode
+            0,               // self_trade_equality_mode
             0,               // skip_nonce
             nonce,
             api_key_index,

--- a/examples/wasm/test_wasm.mjs
+++ b/examples/wasm/test_wasm.mjs
@@ -74,7 +74,7 @@ assert.equal(cancelTxInfo2.Nonce, 42);
 assertSkipNonceAttr("SignCancelOrder (skipNonce=0)", cancelTxInfo2, false);
 assert.notEqual(cancelResult.txHash, cancelResult2.txHash, "skipNonce should affect the signed tx hash");
 
-const cancelAllResult = globalThis.SignCancelAllOrders(0, 0, 1, 42, 0, 1);
+const cancelAllResult = globalThis.SignCancelAllOrders(0, 0, 255, 1, 42, 0, 1);
 console.log("SignCancelAllOrders (skipNonce=1):", cancelAllResult);
 const cancelAllTxInfo = assertSignedTx("SignCancelAllOrders (skipNonce=1)", cancelAllResult, 16);
 assert.equal(cancelAllTxInfo.TimeInForce, 0);
@@ -82,7 +82,7 @@ assert.equal(cancelAllTxInfo.Time, 0);
 assertSkipNonceAttr("SignCancelAllOrders (skipNonce=1)", cancelAllTxInfo, true);
 
 const orderResult = globalThis.SignCreateOrder(
-    0, 1, 1000, 50000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 42, 0, 1
+    0, 1, 1000, 50000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 42, 0, 1
 );
 console.log("SignCreateOrder (skipNonce=1):", orderResult);
 const orderTxInfo = assertSignedTx("SignCreateOrder (skipNonce=1)", orderResult, 14);
@@ -123,7 +123,7 @@ const groupedResult = globalThis.SignCreateGroupedOrders(
             IsAsk: 1, Type: 4, TimeInForce: 0, ReduceOnly: 1, TriggerPrice: 49000, OrderExpiry: expiry,
         },
     ],
-    0, 0, 0, 1, 42, 0, 1
+    0, 0, 0, 0, 0, 1, 42, 0, 1
 );
 console.log("SignCreateGroupedOrders (skipNonce=1):", groupedResult);
 const groupedTxInfo = assertSignedTx("SignCreateGroupedOrders (skipNonce=1)", groupedResult, 28);

--- a/sharedlib/main.go
+++ b/sharedlib/main.go
@@ -121,11 +121,28 @@ func CreateTxAttributesFromIsSkipNonce(skipNonce uint8) *types.L2TxAttributes {
 	return &attr
 }
 
-func CreateIntegratorTxAttributes(integratorAccountIndex int64, integratorTakerFee uint32, integratorMakerFee uint32, skipNonce uint8) *types.L2TxAttributes {
+func CreateIntegratorTxAttributes(integratorAccountIndex int64, integratorTakerFee uint32, integratorMakerFee uint32, skipNonce uint8, selfTradeBehaviorMode uint8, selfTradeEqualityMode uint8) *types.L2TxAttributes {
 	attr := types.L2TxAttributes{}
 	attr.IntegratorAccountIndex = &integratorAccountIndex
 	attr.IntegratorTakerFee = &integratorTakerFee
 	attr.IntegratorMakerFee = &integratorMakerFee
+	if skipNonce == 1 {
+		attr.SkipNonce = &skipNonce
+	}
+	if selfTradeBehaviorMode != txtypes.SelfTradeBehaviorExpireMaker {
+		attr.SelfTradeBehaviorMode = &selfTradeBehaviorMode
+	}
+	if selfTradeEqualityMode != txtypes.SelfTradeEqualityAccountIndex {
+		attr.SelfTradeEqualityMode = &selfTradeEqualityMode
+	}
+	return &attr
+}
+
+func CreateCancelAllTxAttributes(cancelAllMarketIndex int16, skipNonce uint8) *types.L2TxAttributes {
+	attr := types.L2TxAttributes{}
+	if cancelAllMarketIndex != txtypes.NilMarketIndex {
+		attr.CancelAllMarketIndex = &cancelAllMarketIndex
+	}
 	if skipNonce == 1 {
 		attr.SkipNonce = &skipNonce
 	}
@@ -141,13 +158,26 @@ func getTransactOpts(cSkipNonce C.uint8_t, cNonce C.longlong) *types.TransactOpt
 	}
 }
 
-func getIntegratorTransactOptsAll(cIntegratorAccountIndex C.longlong, cIntegratorTakerFee C.int, cIntegratorMakerFee C.int, cSkipNonce C.uint8_t, cNonce C.longlong) *types.TransactOpts {
+func getIntegratorTransactOptsAll(cIntegratorAccountIndex C.longlong, cIntegratorTakerFee C.int, cIntegratorMakerFee C.int, cSkipNonce C.uint8_t, cNonce C.longlong, cSelfTradeBehaviorMode C.uint8_t, cSelfTradeEqualityMode C.uint8_t) *types.TransactOpts {
 	nonce := int64(cNonce)
 	integratorAccountIndex := int64(cIntegratorAccountIndex)
 	integratorTakerFee := uint32(cIntegratorTakerFee)
 	integratorMakerFee := uint32(cIntegratorMakerFee)
 	skipNonce := uint8(cSkipNonce)
-	txAttributes := CreateIntegratorTxAttributes(integratorAccountIndex, integratorTakerFee, integratorMakerFee, skipNonce)
+	selfTradeBehaviorMode := uint8(cSelfTradeBehaviorMode)
+	selfTradeEqualityMode := uint8(cSelfTradeEqualityMode)
+	txAttributes := CreateIntegratorTxAttributes(integratorAccountIndex, integratorTakerFee, integratorMakerFee, skipNonce, selfTradeBehaviorMode, selfTradeEqualityMode)
+	return &types.TransactOpts{
+		Nonce:        &nonce,
+		TxAttributes: txAttributes,
+	}
+}
+
+func getCancelAllTransactOpts(cCancelAllMarketIndex C.int, cSkipNonce C.uint8_t, cNonce C.longlong) *types.TransactOpts {
+	nonce := int64(cNonce)
+	cancelAllMarketIndex := int16(cCancelAllMarketIndex)
+	skipNonce := uint8(cSkipNonce)
+	txAttributes := CreateCancelAllTxAttributes(cancelAllMarketIndex, skipNonce)
 	return &types.TransactOpts{
 		Nonce:        &nonce,
 		TxAttributes: txAttributes,
@@ -243,7 +273,7 @@ func SignChangePubKey(cPubKey *C.char, cSkipNonce C.uint8_t, cNonce C.longlong, 
 }
 
 //export SignCreateOrder
-func SignCreateOrder(cMarketIndex C.int, cClientOrderIndex C.longlong, cBaseAmount C.longlong, cPrice C.int, cIsAsk C.int, cOrderType C.int, cTimeInForce C.int, cReduceOnly C.int, cTriggerPrice C.int, cOrderExpiry C.longlong, cIntegratorAccountIndex C.longlong, cIntegratorTakerFee C.int, cIntegratorMakerFee C.int, cSkipNonce C.uint8_t, cNonce C.longlong, cApiKeyIndex C.int, cAccountIndex C.longlong) (ret C.SignedTxResponse) {
+func SignCreateOrder(cMarketIndex C.int, cClientOrderIndex C.longlong, cBaseAmount C.longlong, cPrice C.int, cIsAsk C.int, cOrderType C.int, cTimeInForce C.int, cReduceOnly C.int, cTriggerPrice C.int, cOrderExpiry C.longlong, cIntegratorAccountIndex C.longlong, cIntegratorTakerFee C.int, cIntegratorMakerFee C.int, cSelfTradeBehaviorMode C.uint8_t, cSelfTradeEqualityMode C.uint8_t, cSkipNonce C.uint8_t, cNonce C.longlong, cApiKeyIndex C.int, cAccountIndex C.longlong) (ret C.SignedTxResponse) {
 	defer func() {
 		if r := recover(); r != nil {
 			ret = signedTxResponsePanic(r)
@@ -282,14 +312,14 @@ func SignCreateOrder(cMarketIndex C.int, cClientOrderIndex C.longlong, cBaseAmou
 		TriggerPrice:     triggerPrice,
 		OrderExpiry:      orderExpiry,
 	}
-	ops := getIntegratorTransactOptsAll(cIntegratorAccountIndex, cIntegratorTakerFee, cIntegratorMakerFee, cSkipNonce, cNonce)
+	ops := getIntegratorTransactOptsAll(cIntegratorAccountIndex, cIntegratorTakerFee, cIntegratorMakerFee, cSkipNonce, cNonce, cSelfTradeBehaviorMode, cSelfTradeEqualityMode)
 
 	txInfo, err := c.GetCreateOrderTransaction(tx, ops)
 	return convertTxInfoToResponse(txInfo, err)
 }
 
 //export SignCreateGroupedOrders
-func SignCreateGroupedOrders(cGroupingType C.uint8_t, cOrders *C.CreateOrderTxReq, cLen C.int, cIntegratorAccountIndex C.longlong, cIntegratorTakerFee C.int, cIntegratorMakerFee C.int, cSkipNonce C.uint8_t, cNonce C.longlong, cApiKeyIndex C.int, cAccountIndex C.longlong) (ret C.SignedTxResponse) {
+func SignCreateGroupedOrders(cGroupingType C.uint8_t, cOrders *C.CreateOrderTxReq, cLen C.int, cIntegratorAccountIndex C.longlong, cIntegratorTakerFee C.int, cIntegratorMakerFee C.int, cSelfTradeBehaviorMode C.uint8_t, cSelfTradeEqualityMode C.uint8_t, cSkipNonce C.uint8_t, cNonce C.longlong, cApiKeyIndex C.int, cAccountIndex C.longlong) (ret C.SignedTxResponse) {
 	defer func() {
 		if r := recover(); r != nil {
 			ret = signedTxResponsePanic(r)
@@ -330,7 +360,7 @@ func SignCreateGroupedOrders(cGroupingType C.uint8_t, cOrders *C.CreateOrderTxRe
 		GroupingType: uint8(cGroupingType),
 		Orders:       orders,
 	}
-	ops := getIntegratorTransactOptsAll(cIntegratorAccountIndex, cIntegratorTakerFee, cIntegratorMakerFee, cSkipNonce, cNonce)
+	ops := getIntegratorTransactOptsAll(cIntegratorAccountIndex, cIntegratorTakerFee, cIntegratorMakerFee, cSkipNonce, cNonce, cSelfTradeBehaviorMode, cSelfTradeEqualityMode)
 
 	txInfo, err := c.GetCreateGroupedOrdersTransaction(tx, ops)
 	return convertTxInfoToResponse(txInfo, err)
@@ -409,7 +439,7 @@ func SignCreateSubAccount(cSkipNonce C.uint8_t, cNonce C.longlong, cApiKeyIndex 
 }
 
 //export SignCancelAllOrders
-func SignCancelAllOrders(cTimeInForce C.int, cTime C.longlong, cSkipNonce C.uint8_t, cNonce C.longlong, cApiKeyIndex C.int, cAccountIndex C.longlong) (ret C.SignedTxResponse) {
+func SignCancelAllOrders(cTimeInForce C.int, cTime C.longlong, cCancelAllMarketIndex C.int, cSkipNonce C.uint8_t, cNonce C.longlong, cApiKeyIndex C.int, cAccountIndex C.longlong) (ret C.SignedTxResponse) {
 	defer func() {
 		if r := recover(); r != nil {
 			ret = signedTxResponsePanic(r)
@@ -428,14 +458,14 @@ func SignCancelAllOrders(cTimeInForce C.int, cTime C.longlong, cSkipNonce C.uint
 		TimeInForce: timeInForce,
 		Time:        t,
 	}
-	ops := getTransactOpts(cSkipNonce, cNonce)
+	ops := getCancelAllTransactOpts(cCancelAllMarketIndex, cSkipNonce, cNonce)
 
 	txInfo, err := c.GetCancelAllOrdersTransaction(tx, ops)
 	return convertTxInfoToResponse(txInfo, err)
 }
 
 //export SignModifyOrder
-func SignModifyOrder(cMarketIndex C.int, cIndex C.longlong, cBaseAmount C.longlong, cPrice C.longlong, cTriggerPrice C.longlong, cIntegratorAccountIndex C.longlong, cIntegratorTakerFee C.int, cIntegratorMakerFee C.int, cSkipNonce C.uint8_t, cNonce C.longlong, cApiKeyIndex C.int, cAccountIndex C.longlong) (ret C.SignedTxResponse) {
+func SignModifyOrder(cMarketIndex C.int, cIndex C.longlong, cBaseAmount C.longlong, cPrice C.longlong, cTriggerPrice C.longlong, cIntegratorAccountIndex C.longlong, cIntegratorTakerFee C.int, cIntegratorMakerFee C.int, cSelfTradeBehaviorMode C.uint8_t, cSelfTradeEqualityMode C.uint8_t, cSkipNonce C.uint8_t, cNonce C.longlong, cApiKeyIndex C.int, cAccountIndex C.longlong) (ret C.SignedTxResponse) {
 	defer func() {
 		if r := recover(); r != nil {
 			ret = signedTxResponsePanic(r)
@@ -460,7 +490,7 @@ func SignModifyOrder(cMarketIndex C.int, cIndex C.longlong, cBaseAmount C.longlo
 		Price:        price,
 		TriggerPrice: triggerPrice,
 	}
-	ops := getIntegratorTransactOptsAll(cIntegratorAccountIndex, cIntegratorTakerFee, cIntegratorMakerFee, cSkipNonce, cNonce)
+	ops := getIntegratorTransactOptsAll(cIntegratorAccountIndex, cIntegratorTakerFee, cIntegratorMakerFee, cSkipNonce, cNonce, cSelfTradeBehaviorMode, cSelfTradeEqualityMode)
 
 	txInfo, err := c.GetModifyOrderTransaction(tx, ops)
 	return convertTxInfoToResponse(txInfo, err)

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -35,11 +35,28 @@ func txAttributesWithSkipNonce(skipNonce uint8) *types.L2TxAttributes {
 	return attr
 }
 
-func integratorTxAttributes(integratorAccountIndex int64, integratorTakerFee uint32, integratorMakerFee uint32, skipNonce uint8) *types.L2TxAttributes {
+func integratorTxAttributes(integratorAccountIndex int64, integratorTakerFee uint32, integratorMakerFee uint32, skipNonce uint8, selfTradeBehaviorMode uint8, selfTradeEqualityMode uint8) *types.L2TxAttributes {
 	attr := &types.L2TxAttributes{
 		IntegratorAccountIndex: &integratorAccountIndex,
 		IntegratorTakerFee:     &integratorTakerFee,
 		IntegratorMakerFee:     &integratorMakerFee,
+	}
+	if skipNonce == 1 {
+		attr.SkipNonce = &skipNonce
+	}
+	if selfTradeBehaviorMode != txtypes.SelfTradeBehaviorExpireMaker {
+		attr.SelfTradeBehaviorMode = &selfTradeBehaviorMode
+	}
+	if selfTradeEqualityMode != txtypes.SelfTradeEqualityAccountIndex {
+		attr.SelfTradeEqualityMode = &selfTradeEqualityMode
+	}
+	return attr
+}
+
+func cancelAllTxAttributes(cancelAllMarketIndex int16, skipNonce uint8) *types.L2TxAttributes {
+	attr := &types.L2TxAttributes{}
+	if cancelAllMarketIndex != txtypes.NilMarketIndex {
+		attr.CancelAllMarketIndex = &cancelAllMarketIndex
 	}
 	if skipNonce == 1 {
 		attr.SkipNonce = &skipNonce
@@ -273,11 +290,11 @@ func main() {
 
 	js.Global().Set("SignCreateOrder", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 		return recoverPanic(func() js.Value {
-			if len(args) < 17 {
-				return js.ValueOf(map[string]interface{}{"error": "SignCreateOrder expects 17 args: marketIndex, clientOrderIndex, baseAmount, price, isAsk, orderType, timeInForce, reduceOnly, triggerPrice, orderExpiry, integratorAccountIndex, integratorTakerFee, integratorMakerFee, skipNonce, nonce, apiKeyIndex, accountIndex"})
+			if len(args) < 19 {
+				return js.ValueOf(map[string]interface{}{"error": "SignCreateOrder expects 19 args: marketIndex, clientOrderIndex, baseAmount, price, isAsk, orderType, timeInForce, reduceOnly, triggerPrice, orderExpiry, integratorAccountIndex, integratorTakerFee, integratorMakerFee, selfTradeBehaviorMode, selfTradeEqualityMode, skipNonce, nonce, apiKeyIndex, accountIndex"})
 			}
 			// Validate all arguments are defined before accessing
-			for i := 0; i < 17; i++ {
+			for i := 0; i < 19; i++ {
 				if args[i].Type() == js.TypeUndefined {
 					return js.ValueOf(map[string]interface{}{"error": fmt.Sprintf("argument %d is undefined", i)})
 				}
@@ -339,11 +356,19 @@ func main() {
 			if err != nil {
 				return wrapErr(err)
 			}
-			skipNonce, err := safeUint8(args[13], 13)
+			selfTradeBehaviorMode, err := safeUint8(args[13], 13)
 			if err != nil {
 				return wrapErr(err)
 			}
-			nonce, err := safeInt(args[14], 14)
+			selfTradeEqualityMode, err := safeUint8(args[14], 14)
+			if err != nil {
+				return wrapErr(err)
+			}
+			skipNonce, err := safeUint8(args[15], 15)
+			if err != nil {
+				return wrapErr(err)
+			}
+			nonce, err := safeInt(args[16], 16)
 			if err != nil {
 				return wrapErr(err)
 			}
@@ -365,7 +390,7 @@ func main() {
 				OrderExpiry:      orderExpiry,
 			}
 			ops := new(types.TransactOpts)
-			ops.TxAttributes = integratorTxAttributes(integratorAccountIndex, integratorTakerFee, integratorMakerFee, skipNonce)
+			ops.TxAttributes = integratorTxAttributes(integratorAccountIndex, integratorTakerFee, integratorMakerFee, skipNonce, selfTradeBehaviorMode, selfTradeEqualityMode)
 			if nonce != -1 {
 				ops.Nonce = &nonce
 			}
@@ -410,8 +435,8 @@ func main() {
 
 	js.Global().Set("SignCancelAllOrders", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 		return recoverPanic(func() js.Value {
-			if len(args) < 6 {
-				return js.ValueOf(map[string]interface{}{"error": "SignCancelAllOrders expects 6 args: timeInForce, time, skipNonce, nonce, apiKeyIndex, accountIndex"})
+			if len(args) < 7 {
+				return js.ValueOf(map[string]interface{}{"error": "SignCancelAllOrders expects 7 args: timeInForce, time, cancelAllMarketIndex, skipNonce, nonce, apiKeyIndex, accountIndex"})
 			}
 			c, err := getClient(args)
 			if err != nil {
@@ -420,15 +445,16 @@ func main() {
 
 			timeInForce := uint8(args[0].Int())
 			timeVal := int64(args[1].Int())
-			skipNonce := uint8(args[2].Int())
-			nonce := int64(args[3].Int())
+			cancelAllMarketIndex := int16(args[2].Int())
+			skipNonce := uint8(args[3].Int())
+			nonce := int64(args[4].Int())
 
 			txInfo := &types.CancelAllOrdersTxReq{
 				TimeInForce: timeInForce,
 				Time:        timeVal,
 			}
 			ops := new(types.TransactOpts)
-			ops.TxAttributes = txAttributesWithSkipNonce(skipNonce)
+			ops.TxAttributes = cancelAllTxAttributes(cancelAllMarketIndex, skipNonce)
 			if nonce != -1 {
 				ops.Nonce = &nonce
 			}
@@ -629,8 +655,8 @@ func main() {
 
 	js.Global().Set("SignModifyOrder", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 		return recoverPanic(func() js.Value {
-			if len(args) < 12 {
-				return js.ValueOf(map[string]interface{}{"error": "SignModifyOrder expects 12 args: marketIndex, index, baseAmount, price, triggerPrice, integratorAccountIndex, integratorTakerFee, integratorMakerFee, skipNonce, nonce, apiKeyIndex, accountIndex"})
+			if len(args) < 14 {
+				return js.ValueOf(map[string]interface{}{"error": "SignModifyOrder expects 14 args: marketIndex, index, baseAmount, price, triggerPrice, integratorAccountIndex, integratorTakerFee, integratorMakerFee, selfTradeBehaviorMode, selfTradeEqualityMode, skipNonce, nonce, apiKeyIndex, accountIndex"})
 			}
 			c, err := getClient(args)
 			if err != nil {
@@ -648,8 +674,10 @@ func main() {
 			integratorAccountIndex := int64(args[5].Int())
 			integratorTakerFee := uint32(args[6].Int())
 			integratorMakerFee := uint32(args[7].Int())
-			skipNonce := uint8(args[8].Int())
-			nonce := int64(args[9].Int())
+			selfTradeBehaviorMode := uint8(args[8].Int())
+			selfTradeEqualityMode := uint8(args[9].Int())
+			skipNonce := uint8(args[10].Int())
+			nonce := int64(args[11].Int())
 
 			txInfo := &types.ModifyOrderTxReq{
 				MarketIndex:  marketIndex,
@@ -659,7 +687,7 @@ func main() {
 				TriggerPrice: triggerPrice,
 			}
 			ops := new(types.TransactOpts)
-			ops.TxAttributes = integratorTxAttributes(integratorAccountIndex, integratorTakerFee, integratorMakerFee, skipNonce)
+			ops.TxAttributes = integratorTxAttributes(integratorAccountIndex, integratorTakerFee, integratorMakerFee, skipNonce, selfTradeBehaviorMode, selfTradeEqualityMode)
 			if nonce != -1 {
 				ops.Nonce = &nonce
 			}
@@ -925,8 +953,8 @@ func main() {
 
 	js.Global().Set("SignCreateGroupedOrders", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 		return recoverPanic(func() js.Value {
-			if len(args) < 9 {
-				return js.ValueOf(map[string]interface{}{"error": "SignCreateGroupedOrders expects 9 args: groupingType, orders array, integratoraccountindex, integratortakerfee, integratormakerfee, skipnonce, nonce, apiKeyIndex, accountIndex"})
+			if len(args) < 11 {
+				return js.ValueOf(map[string]interface{}{"error": "SignCreateGroupedOrders expects 11 args: groupingType, orders array, integratoraccountindex, integratortakerfee, integratormakerfee, selfTradeBehaviorMode, selfTradeEqualityMode, skipnonce, nonce, apiKeyIndex, accountIndex"})
 			}
 			c, err := getClient(args)
 			if err != nil {
@@ -946,7 +974,9 @@ func main() {
 			integratorAccountIndex := int64(args[2].Int())
 			integratorTakerFee := uint32(args[3].Int())
 			integratorMakerFee := uint32(args[4].Int())
-			skipNonce := uint8(args[5].Int())
+			selfTradeBehaviorMode := uint8(args[5].Int())
+			selfTradeEqualityMode := uint8(args[6].Int())
+			skipNonce := uint8(args[7].Int())
 
 			for i := 0; i < length; i++ {
 				orderObj := ordersArg.Index(i)
@@ -973,7 +1003,7 @@ func main() {
 				}
 			}
 
-			nonce := int64(args[6].Int())
+			nonce := int64(args[8].Int())
 
 			req := &types.CreateGroupedOrdersTxReq{
 				GroupingType: groupingType,
@@ -981,7 +1011,7 @@ func main() {
 			}
 
 			ops := new(types.TransactOpts)
-			ops.TxAttributes = integratorTxAttributes(integratorAccountIndex, integratorTakerFee, integratorMakerFee, skipNonce)
+			ops.TxAttributes = integratorTxAttributes(integratorAccountIndex, integratorTakerFee, integratorMakerFee, skipNonce, selfTradeBehaviorMode, selfTradeEqualityMode)
 			if nonce != -1 {
 				ops.Nonce = &nonce
 			}


### PR DESCRIPTION
## Summary
The `self-trade` branch (#75) added `SelfTradeBehaviorMode`, `SelfTradeEqualityMode`, and `CancelAllMarketIndex` to `types.L2TxAttributes`, but only at the `types`/`txtypes` layer — the C-FFI (`sharedlib/main.go`) and WASM (`wasm/main.go`) entrypoints had no way to set them. This PR wires those three attributes through both bindings via the existing attribute builders. Targets the `self-trade` branch since it depends on those type changes.

What's exposed where:
- `SignCreateOrder` / `SignCreateGroupedOrders` / `SignModifyOrder` → new `selfTradeBehaviorMode`, `selfTradeEqualityMode` params
- `SignCancelAllOrders` → new `cancelAllMarketIndex` param

Builders only set a pointer when the value differs from its nil/default (`SelfTradeBehaviorExpireMaker=0`, `SelfTradeEqualityAccountIndex=0`, `NilMarketIndex=255`), so passing defaults produces byte-identical signatures to before (verified: WASM `SignCreateOrder` still emits `L2TxAttributes` without keys 6/7).

```
// sharedlib
CreateIntegratorTxAttributes(..., skipNonce, selfTradeBehaviorMode, selfTradeEqualityMode)
CreateCancelAllTxAttributes(cancelAllMarketIndex, skipNonce)   // new helper
// wasm
integratorTxAttributes(..., skipNonce, selfTradeBehaviorMode, selfTradeEqualityMode)
cancelAllTxAttributes(cancelAllMarketIndex, skipNonce)         // new helper
```

New args are inserted **after** the integrator-fee params and **before** `skipNonce`, keeping `apiKeyIndex`/`accountIndex` last (WASM `getClient` reads them from the tail). WASM arg-count checks and "expects N args" messages bumped accordingly.

### Example call sites (required to keep CI green)
CI compiles and runs the C++/Java/Rust/WASM examples, which call these exported functions, so their call sites were mechanically updated to pass the new defaults (`0`/`0`/`255`) — no logic changes. This is the only reason the PR touches `examples/`.

### Verification
- `go build -buildmode=c-shared` (sharedlib) + generated header signatures confirmed
- `go build GOOS=js GOARCH=wasm` (wasm) + `node examples/wasm/test_wasm.mjs` → all assertions pass
- `cargo build --release` (rust example) + g++ compile of cpp example
- `gofmt`, `go vet`, `go test ./...` clean
- (Java/`mvn` not available locally; JNA interface updated to match the generated header)


Link to Devin session: https://app.devin.ai/sessions/08b2387465664e789286a14d3078a1a4
Requested by: @mihaimarcu2004
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/elliottech/lighter-go/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->