### PR TITLE
fix(wasm): accept order index as a string or number in SignCancelOrder and SignModifyOrder

### DIFF
--- a/wasm/main.go
+++ b/wasm/main.go
@@ -682,7 +682,17 @@ func main() {
 			if err != nil {
 				return wrapErr(err)
 			}
-			index := int64(args[1].Int())
+
+			var index int64
+			if args[1].Type() == js.TypeString {
+				index, err = strconv.ParseInt(args[1].String(), 10, 64)
+				if err != nil {
+					return wrapErr(err)
+				}
+			} else {
+				index = int64(args[1].Int())
+			}
+			
 			baseAmount := int64(args[2].Int())
 			price := uint32(args[3].Int())
 			triggerPrice := uint32(args[4].Int())

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -419,7 +419,17 @@ func main() {
 			if err != nil {
 				return wrapErr(err)
 			}
-			orderIndex := int64(args[1].Int())
+
+			var orderIndex int64
+			if args[1].Type() == js.TypeString {
+				orderIndex, err = strconv.ParseInt(args[1].String(), 10, 64)
+				if err != nil {
+					return wrapErr(err)
+				}
+			} else {
+				orderIndex = int64(args[1].Int())
+			}
+
 			skipNonce := uint8(args[2].Int())
 			nonce := int64(args[3].Int())
 


### PR DESCRIPTION
## Problem
- WASM `SignCancelOrder` and `SignModifyOrder` read the order index via `int64(args[1].Int())`
- Any order index above  [Number.MAX_SAFE_INTEGER](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER)  (2^53 - 1) is not guaranteed to be represented exactly as a JS number, so .Int() can carry a different value into the tx, which then gets signed with no error.
- This is reachable in normal use - server order indices span [2^48, 2^60-1] based on: https://github.com/elliottech/lighter-go/blob/c26ac340ce5d2e237c555949b6ab0927bd09e0df/types/txtypes/constants.go#L211-L212

## Fix
- Accept the index as a string or number in both functions: parse strings with `strconv.ParseInt` (full `int64`), fall back to `.Int()` for numbers

## Validation
- `GOOS=js GOARCH=wasm go build ./wasm/` and `go vet` pass