### PR TITLE
Make normal single-order signing ~30× faster (1.95 ms → 63.9 µs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           sudo apt-get install -y gcc-mingw-w64-x86-64
           CGO_ENABLED=1 GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc \
             go build -buildmode=c-shared -trimpath \
-            -o ./build/lighter-signer-windows-amd64.dll ./sharedlib/main.go
+            -o ./build/lighter-signer-windows-amd64.dll ./sharedlib
 
       # make sure examples are building & test
       - run: go test ./...

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,13 @@ go 1.23.0
 toolchain go1.23.1
 
 require (
-	github.com/elliottech/poseidon_crypto v0.0.15
+	github.com/elliottech/poseidon_crypto v0.0.18
 	github.com/ethereum/go-ethereum v1.15.6
 )
+
+// Temporary review pin: after poseidon_crypto publishes the fixed-generator
+// signing changes, bump the requirement above to v0.0.19 and delete this replace.
+replace github.com/elliottech/poseidon_crypto => github.com/josusanmartin/poseidon_crypto v0.0.19-0.20260806103651-53cabb8c2dbf
 
 require (
 	github.com/bits-and-blooms/bitset v1.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,6 @@ github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1m5sE92cU+pd5Mcc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
-github.com/elliottech/poseidon_crypto v0.0.15 h1:+f/YTnIFEWX1Xss75Ky7QRvhDpR372XAAMtpWxKvp+k=
-github.com/elliottech/poseidon_crypto v0.0.15/go.mod h1:/nFxH8V+3yk3eakI+Arlu5U8XwRXgydBvsiwfA/yYrg=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=
 github.com/ethereum/c-kzg-4844 v1.0.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/ethereum/go-ethereum v1.15.6 h1:jgLoUM6/pNjp0uEnXyWcWikDwa4j1wZlcqkX8Pm8A+I=
@@ -37,6 +35,8 @@ github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb/go.mod h1:/XxbfmMg
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/holiman/uint256 v1.3.2 h1:a9EgMPSC1AAaj1SZL5zIQD3WbwTuHrMGOerLjGmM/TA=
 github.com/holiman/uint256 v1.3.2/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
+github.com/josusanmartin/poseidon_crypto v0.0.19-0.20260806103651-53cabb8c2dbf h1:GlsMXKca2ktJN97izS0/41nh1dhj74uHG8JrUj8lyKM=
+github.com/josusanmartin/poseidon_crypto v0.0.19-0.20260806103651-53cabb8c2dbf/go.mod h1:/nFxH8V+3yk3eakI+Arlu5U8XwRXgydBvsiwfA/yYrg=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leanovate/gopter v0.2.11 h1:vRjThO1EKPb/1NsDXuDrzldR28RLkBflWYcU9CvzWu4=

--- a/justfile
+++ b/justfile
@@ -8,20 +8,20 @@ build-all:
 
 build-darwin-local:
     go mod vendor
-    go build -buildmode=c-shared -trimpath -o ./build/lighter-signer-darwin-arm64.dylib ./sharedlib/main.go
+    go build -buildmode=c-shared -trimpath -o ./build/lighter-signer-darwin-arm64.dylib ./sharedlib
 
 # Note: build-linux-local does not append -arm or amd64 at end
 build-linux-local:
     go mod vendor
-    CGO_ENABLED=1 go build -buildmode=c-shared -trimpath -o ./build/lighter-signer-linux.so ./sharedlib/main.go
+    CGO_ENABLED=1 go build -buildmode=c-shared -trimpath -o ./build/lighter-signer-linux.so ./sharedlib
 
 # Note: build-windows-local does not append -arm or amd64 at end
 # Windows build (requires gcc from msys2: choco install msys2)
-# CMD:        set PATH=C:\msys64\mingw64\bin;%PATH% && set CGO_ENABLED=1 && go mod vendor && go build -buildmode=c-shared -trimpath -o ./build/signer-amd64.dll ./sharedlib/main.go
-# PowerShell: $env:Path='C:\msys64\mingw64\bin;'+$env:Path; $env:CGO_ENABLED='1'; go mod vendor; go build -buildmode=c-shared -trimpath -o ./build/signer-amd64.dll ./sharedlib/main.go
+# CMD:        set PATH=C:\msys64\mingw64\bin;%PATH% && set CGO_ENABLED=1 && go mod vendor && go build -buildmode=c-shared -trimpath -o ./build/signer-amd64.dll ./sharedlib
+# PowerShell: $env:Path='C:\msys64\mingw64\bin;'+$env:Path; $env:CGO_ENABLED='1'; go mod vendor; go build -buildmode=c-shared -trimpath -o ./build/signer-amd64.dll ./sharedlib
 build-windows-local:
     go mod vendor
-    $env:Path='C:\msys64\mingw64\bin;'+$env:Path; $env:CGO_ENABLED='1'; go build -buildmode=c-shared -trimpath -o ./build/lighter-signer-windows.dll ./sharedlib/main.go
+    $env:Path='C:\msys64\mingw64\bin;'+$env:Path; $env:CGO_ENABLED='1'; go build -buildmode=c-shared -trimpath -o ./build/lighter-signer-windows.dll ./sharedlib
 
 ### Docker builds
 
@@ -50,7 +50,7 @@ build-windows-amd64-docker:
 
 build-darwin-amd64-local:
     go mod vendor
-    go build -buildmode=c-shared -trimpath -o ./build/lighter-signer-darwin-amd64.dylib ./sharedlib/main.go
+    go build -buildmode=c-shared -trimpath -o ./build/lighter-signer-darwin-amd64.dylib ./sharedlib
 
 ### WASM builds
 

--- a/sharedlib/main.go
+++ b/sharedlib/main.go
@@ -1,19 +1,25 @@
 package main
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"math"
+	"runtime"
+	"sync"
 	"time"
 	"unsafe"
 
 	"github.com/elliottech/lighter-go/client"
 	"github.com/elliottech/lighter-go/client/http"
+	"github.com/elliottech/lighter-go/signer"
 	"github.com/elliottech/lighter-go/types"
 	"github.com/elliottech/lighter-go/types/txtypes"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 /*
+#cgo CFLAGS: -std=c11
 #include <stdlib.h>
 #include <stdint.h>
 typedef struct {
@@ -28,6 +34,12 @@ typedef struct {
 	char* messageToSign;
 	char* err;
 } SignedTxResponse;
+
+typedef struct {
+	void* data;
+	int64_t len;
+	char* err;
+} SignedTxBatchResponse;
 
 typedef struct {
 	char* privateKey;
@@ -78,6 +90,66 @@ func signedTxResponseErr(err any) C.SignedTxResponse {
 
 func signedTxResponsePanic(err any) C.SignedTxResponse {
 	return signedTxResponseErr(fmt.Errorf("panic: %v", err))
+}
+
+func signedTxBatchResponseErr(err any) C.SignedTxBatchResponse {
+	return C.SignedTxBatchResponse{err: wrapErr(err)}
+}
+
+type packedSignedTxResponse struct {
+	txType uint8
+	txInfo string
+	txHash string
+	err    string
+}
+
+func convertTxInfoToPackedResponse(txInfo txtypes.TxInfo, err error) packedSignedTxResponse {
+	if err != nil {
+		return packedSignedTxResponse{err: err.Error()}
+	}
+	if txInfo == nil {
+		return packedSignedTxResponse{err: "nil transaction info"}
+	}
+
+	txInfoStr, err := txInfo.GetTxInfo()
+	if err != nil {
+		return packedSignedTxResponse{err: err.Error()}
+	}
+	return packedSignedTxResponse{
+		txType: uint8(txInfo.GetTxType()),
+		txInfo: txInfoStr,
+		txHash: txInfo.GetTxHash(),
+	}
+}
+
+const packedSignedTxHeaderSize = 16
+
+func marshalSignedTxResponses(results []packedSignedTxResponse) []byte {
+	totalSize := 4
+	for _, result := range results {
+		totalSize += packedSignedTxHeaderSize + len(result.txInfo) + len(result.txHash) + len(result.err)
+	}
+
+	packed := make([]byte, totalSize)
+	binary.LittleEndian.PutUint32(packed, uint32(len(results)))
+	offset := 4
+	for _, result := range results {
+		packed[offset] = result.txType
+		binary.LittleEndian.PutUint32(packed[offset+4:], uint32(len(result.txInfo)))
+		binary.LittleEndian.PutUint32(packed[offset+8:], uint32(len(result.txHash)))
+		binary.LittleEndian.PutUint32(packed[offset+12:], uint32(len(result.err)))
+		offset += packedSignedTxHeaderSize
+		offset += copy(packed[offset:], result.txInfo)
+		offset += copy(packed[offset:], result.txHash)
+		offset += copy(packed[offset:], result.err)
+	}
+
+	return packed
+}
+
+func packSignedTxResponses(results []packedSignedTxResponse) C.SignedTxBatchResponse {
+	packed := marshalSignedTxResponses(results)
+	return C.SignedTxBatchResponse{data: C.CBytes(packed), len: C.int64_t(len(packed))}
 }
 
 func convertTxInfoToResponse(txInfo txtypes.TxInfo, err error) C.SignedTxResponse {
@@ -245,6 +317,16 @@ func CheckClient(cApiKeyIndex C.int, cAccountIndex C.longlong) (ret *C.char) {
 	return wrapErr(c.Check())
 }
 
+//export PrepareSignerNonces
+func PrepareSignerNonces(cCount C.int) (ret *C.char) {
+	defer func() {
+		if r := recover(); r != nil {
+			ret = wrapErr(fmt.Errorf("panic: %v", r))
+		}
+	}()
+	return wrapErr(signer.PrepareSchnorrNonces(int(cCount)))
+}
+
 //export SignChangePubKey
 func SignChangePubKey(cPubKey *C.char, cSkipNonce C.uint8_t, cNonce C.longlong, cApiKeyIndex C.int, cAccountIndex C.longlong) (ret C.SignedTxResponse) {
 	defer func() {
@@ -303,7 +385,7 @@ func SignCreateOrder(cMarketIndex C.int, cClientOrderIndex C.longlong, cBaseAmou
 	orderExpiry := int64(cOrderExpiry)
 
 	if orderExpiry == -1 {
-		orderExpiry = time.Now().Add(time.Hour * 24 * 28).UnixMilli() // 28 days
+		orderExpiry = time.Now().Add(defaultOrderExpiryDuration).UnixMilli()
 	}
 
 	tx := &types.CreateOrderTxReq{
@@ -322,6 +404,155 @@ func SignCreateOrder(cMarketIndex C.int, cClientOrderIndex C.longlong, cBaseAmou
 
 	txInfo, err := c.GetCreateOrderTransaction(tx, ops)
 	return convertTxInfoToResponse(txInfo, err)
+}
+
+const (
+	maxCreateOrderBatch        = 10_000
+	defaultOrderExpiryDuration = 28 * 24 * time.Hour
+)
+
+type createOrderBatchOptions struct {
+	integratorAccountIndex int64
+	integratorTakerFee     uint32
+	integratorMakerFee     uint32
+	selfTradeBehaviorMode  uint8
+	selfTradeEqualityMode  uint8
+	skipNonce              uint8
+	firstNonce             int64
+	requestedAPIKeyIndex   uint8
+	requestedAccountIndex  int64
+}
+
+func signCreateOrdersBatch(orders []types.CreateOrderTxReq, options createOrderBatchOptions) ([]packedSignedTxResponse, error) {
+	length := len(orders)
+	if length <= 0 || length > maxCreateOrderBatch {
+		return nil, fmt.Errorf("batch length must be between 1 and %d", maxCreateOrderBatch)
+	}
+	if options.firstNonce < 0 {
+		return nil, fmt.Errorf("batch signing requires an explicit non-negative first nonce; it does not perform network I/O")
+	}
+	if options.firstNonce > math.MaxInt64-int64(length-1) {
+		return nil, fmt.Errorf("batch nonce range overflows int64")
+	}
+
+	c, err := client.GetClient(options.requestedAPIKeyIndex, options.requestedAccountIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]packedSignedTxResponse, length)
+	keyManager := c.GetKeyManager()
+	chainID := c.GetChainId()
+	accountIndex := c.GetAccountIndex()
+	apiKeyIndex := c.GetApiKeyIndex()
+	expiredAt := time.Now().Add(client.DefaultExpireTime).UnixMilli()
+	defaultOrderExpiry := time.Now().Add(defaultOrderExpiryDuration).UnixMilli()
+	txAttributes := CreateIntegratorTxAttributes(
+		options.integratorAccountIndex,
+		options.integratorTakerFee,
+		options.integratorMakerFee,
+		options.skipNonce,
+		options.selfTradeBehaviorMode,
+		options.selfTradeEqualityMode,
+	)
+
+	// A batch call uses up to GOMAXPROCS workers and can therefore occupy every
+	// available Go execution slot until the batch completes.
+	workerCount := min(length, runtime.GOMAXPROCS(0))
+	signRange := func(start, end int) {
+		for i := start; i < end; i++ {
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						results[i] = packedSignedTxResponse{err: fmt.Sprintf("panic: %v", r)}
+					}
+				}()
+
+				order := orders[i]
+				if order.OrderExpiry == -1 {
+					order.OrderExpiry = defaultOrderExpiry
+				}
+				nonce := options.firstNonce + int64(i)
+				ops := &types.TransactOpts{
+					FromAccountIndex: &accountIndex,
+					ApiKeyIndex:      &apiKeyIndex,
+					ExpiredAt:        expiredAt,
+					Nonce:            &nonce,
+					TxAttributes:     txAttributes,
+				}
+				txInfo, signErr := types.ConstructCreateOrderTx(
+					keyManager, chainID, &order, ops,
+				)
+				results[i] = convertTxInfoToPackedResponse(txInfo, signErr)
+			}()
+		}
+	}
+
+	if workerCount == 1 {
+		signRange(0, length)
+	} else {
+		var workers sync.WaitGroup
+		workers.Add(workerCount)
+		for worker := 0; worker < workerCount; worker++ {
+			start := worker * length / workerCount
+			end := (worker + 1) * length / workerCount
+			go func() {
+				defer workers.Done()
+				signRange(start, end)
+			}()
+		}
+		workers.Wait()
+	}
+	return results, nil
+}
+
+//export SignCreateOrdersBatch
+func SignCreateOrdersBatch(cOrders *C.CreateOrderTxReq, cLen C.int, cIntegratorAccountIndex C.longlong, cIntegratorTakerFee C.int, cIntegratorMakerFee C.int, cSelfTradeBehaviorMode C.uint8_t, cSelfTradeEqualityMode C.uint8_t, cSkipNonce C.uint8_t, cFirstNonce C.longlong, cApiKeyIndex C.int, cAccountIndex C.longlong) (ret C.SignedTxBatchResponse) {
+	defer func() {
+		if r := recover(); r != nil {
+			ret = signedTxBatchResponseErr(fmt.Errorf("panic: %v", r))
+		}
+	}()
+
+	length := int(cLen)
+	if length <= 0 || length > maxCreateOrderBatch {
+		return signedTxBatchResponseErr(fmt.Errorf("batch length must be between 1 and %d", maxCreateOrderBatch))
+	}
+	if cOrders == nil {
+		return signedTxBatchResponseErr("batch input pointer is required")
+	}
+
+	cOrdersSlice := unsafe.Slice(cOrders, length)
+	orders := make([]types.CreateOrderTxReq, length)
+	for i, order := range cOrdersSlice {
+		orders[i] = types.CreateOrderTxReq{
+			MarketIndex:      int16(order.MarketIndex),
+			ClientOrderIndex: int64(order.ClientOrderIndex),
+			BaseAmount:       int64(order.BaseAmount),
+			Price:            uint32(order.Price),
+			IsAsk:            uint8(order.IsAsk),
+			Type:             uint8(order.Type),
+			TimeInForce:      uint8(order.TimeInForce),
+			ReduceOnly:       uint8(order.ReduceOnly),
+			TriggerPrice:     uint32(order.TriggerPrice),
+			OrderExpiry:      int64(order.OrderExpiry),
+		}
+	}
+	results, err := signCreateOrdersBatch(orders, createOrderBatchOptions{
+		integratorAccountIndex: int64(cIntegratorAccountIndex),
+		integratorTakerFee:     uint32(cIntegratorTakerFee),
+		integratorMakerFee:     uint32(cIntegratorMakerFee),
+		selfTradeBehaviorMode:  uint8(cSelfTradeBehaviorMode),
+		selfTradeEqualityMode:  uint8(cSelfTradeEqualityMode),
+		skipNonce:              uint8(cSkipNonce),
+		firstNonce:             int64(cFirstNonce),
+		requestedAPIKeyIndex:   uint8(cApiKeyIndex),
+		requestedAccountIndex:  int64(cAccountIndex),
+	})
+	if err != nil {
+		return signedTxBatchResponseErr(err)
+	}
+	return packSignedTxResponses(results)
 }
 
 //export SignCreateGroupedOrders
@@ -345,7 +576,7 @@ func SignCreateGroupedOrders(cGroupingType C.uint8_t, cOrders *C.CreateOrderTxRe
 
 		orderExpiry := int64(order.OrderExpiry)
 		if orderExpiry == -1 {
-			orderExpiry = time.Now().Add(time.Hour * 24 * 28).UnixMilli()
+			orderExpiry = time.Now().Add(defaultOrderExpiryDuration).UnixMilli()
 		}
 
 		orders[i] = &types.CreateOrderTxReq{

--- a/sharedlib/main_test.go
+++ b/sharedlib/main_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/elliottech/lighter-go/client"
+	"github.com/elliottech/lighter-go/types"
+	curve "github.com/elliottech/poseidon_crypto/curve/ecgfp5"
+)
+
+const (
+	testBatchAccountIndex = int64(424_242)
+	testBatchAPIKeyIndex  = uint8(3)
+	defaultAPIKeyIndex    = uint8(255)
+)
+
+func registerBatchTestClient(t *testing.T) {
+	t.Helper()
+	privateKey := "0x" + hex.EncodeToString(curve.ONE.ToLittleEndianBytes())
+	if _, err := client.CreateClient(
+		nil, privateKey, 304, testBatchAPIKeyIndex, testBatchAccountIndex,
+	); err != nil {
+		t.Fatalf("create test client: %v", err)
+	}
+}
+
+func validBatchOrder(index int) types.CreateOrderTxReq {
+	return types.CreateOrderTxReq{
+		MarketIndex:      0,
+		ClientOrderIndex: int64(index + 1),
+		BaseAmount:       1_000,
+		Price:            50_000,
+		Type:             0,
+		TimeInForce:      0,
+		OrderExpiry:      0,
+	}
+}
+
+func defaultBatchOptions(firstNonce int64) createOrderBatchOptions {
+	return createOrderBatchOptions{
+		firstNonce:             firstNonce,
+		requestedAPIKeyIndex:   defaultAPIKeyIndex,
+		requestedAccountIndex:  testBatchAccountIndex,
+		integratorAccountIndex: 0,
+	}
+}
+
+func TestSignCreateOrdersBatchResolvesDefaultClient(t *testing.T) {
+	registerBatchTestClient(t)
+	results, err := signCreateOrdersBatch(
+		[]types.CreateOrderTxReq{validBatchOrder(0), validBatchOrder(1)},
+		defaultBatchOptions(700),
+	)
+	if err != nil {
+		t.Fatalf("sign batch: %v", err)
+	}
+	for i, result := range results {
+		if result.err != "" {
+			t.Fatalf("result %d failed: %s", i, result.err)
+		}
+		var tx struct {
+			AccountIndex int64 `json:"AccountIndex"`
+			APIKeyIndex  uint8 `json:"ApiKeyIndex"`
+			Nonce        int64 `json:"Nonce"`
+		}
+		if err := json.Unmarshal([]byte(result.txInfo), &tx); err != nil {
+			t.Fatalf("decode result %d: %v", i, err)
+		}
+		if tx.AccountIndex != testBatchAccountIndex || tx.APIKeyIndex != testBatchAPIKeyIndex {
+			t.Fatalf("result %d used account/key %d/%d", i, tx.AccountIndex, tx.APIKeyIndex)
+		}
+		if want := int64(700 + i); tx.Nonce != want {
+			t.Fatalf("result %d nonce = %d, want %d", i, tx.Nonce, want)
+		}
+	}
+}
+
+func TestSignCreateOrdersBatchRequiresExplicitNonce(t *testing.T) {
+	registerBatchTestClient(t)
+	_, err := signCreateOrdersBatch(
+		[]types.CreateOrderTxReq{validBatchOrder(0), validBatchOrder(1)},
+		defaultBatchOptions(-1),
+	)
+	if err == nil || !strings.Contains(err.Error(), "explicit non-negative first nonce") {
+		t.Fatalf("first nonce -1 error = %v", err)
+	}
+}
+
+func TestSignCreateOrdersBatchMixedPerItemErrors(t *testing.T) {
+	registerBatchTestClient(t)
+	orders := []types.CreateOrderTxReq{
+		validBatchOrder(0),
+		validBatchOrder(1),
+		validBatchOrder(2),
+	}
+	orders[1].BaseAmount = 0
+	results, err := signCreateOrdersBatch(orders, defaultBatchOptions(800))
+	if err != nil {
+		t.Fatalf("sign batch: %v", err)
+	}
+	if results[0].err != "" || results[2].err != "" {
+		t.Fatalf("valid results failed: %q, %q", results[0].err, results[2].err)
+	}
+	if !strings.Contains(results[1].err, "BaseAmount") {
+		t.Fatalf("invalid result error = %q", results[1].err)
+	}
+}
+
+func TestSignCreateOrdersBatchBounds(t *testing.T) {
+	registerBatchTestClient(t)
+	if _, err := signCreateOrdersBatch(nil, defaultBatchOptions(0)); err == nil {
+		t.Fatal("empty batch succeeded")
+	}
+	if _, err := signCreateOrdersBatch(
+		make([]types.CreateOrderTxReq, maxCreateOrderBatch+1), defaultBatchOptions(0),
+	); err == nil {
+		t.Fatal("oversized batch succeeded")
+	}
+	if _, err := signCreateOrdersBatch(
+		[]types.CreateOrderTxReq{validBatchOrder(0), validBatchOrder(1)},
+		defaultBatchOptions(math.MaxInt64),
+	); err == nil || !strings.Contains(err.Error(), "overflows") {
+		t.Fatalf("overflowing nonce range error = %v", err)
+	}
+}
+
+func TestSignCreateOrdersBatchParallel(t *testing.T) {
+	registerBatchTestClient(t)
+	const count = 2_000
+	orders := make([]types.CreateOrderTxReq, count)
+	for i := range orders {
+		orders[i] = validBatchOrder(i)
+	}
+	results, err := signCreateOrdersBatch(orders, defaultBatchOptions(1_000))
+	if err != nil {
+		t.Fatalf("sign parallel batch: %v", err)
+	}
+	hashes := make(map[string]struct{}, count)
+	for i, result := range results {
+		if result.err != "" {
+			t.Fatalf("result %d failed: %s", i, result.err)
+		}
+		if _, exists := hashes[result.txHash]; exists {
+			t.Fatalf("duplicate signed hash at result %d", i)
+		}
+		hashes[result.txHash] = struct{}{}
+	}
+}
+
+func TestMarshalSignedTxResponses(t *testing.T) {
+	packed := marshalSignedTxResponses([]packedSignedTxResponse{
+		{txType: 14, txInfo: "tx", txHash: "hash"},
+		{err: "bad order"},
+	})
+	if got := binary.LittleEndian.Uint32(packed[:4]); got != 2 {
+		t.Fatalf("packed count = %d, want 2", got)
+	}
+	if len(packed) != 4+2*packedSignedTxHeaderSize+2+4+len("bad order") {
+		t.Fatalf("packed length = %d", len(packed))
+	}
+}
+
+func TestFastEnableStackBoundCacheIsIdempotent(t *testing.T) {
+	first := FastEnableStackBoundCache()
+	if second := FastEnableStackBoundCache(); second != first {
+		t.Fatalf("cache enable result changed from %d to %d", first, second)
+	}
+}

--- a/sharedlib/stack_bound_cache.c
+++ b/sharedlib/stack_bound_cache.c
@@ -1,0 +1,99 @@
+#include "stack_bound_cache.h"
+
+#include <stdatomic.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#if \
+    defined(__APPLE__) || defined(__GLIBC__) || \
+    defined(__sun)
+#define LIGHTER_HAS_EXACT_STACK_BOUNDS 1
+#endif
+
+#if defined(LIGHTER_HAS_EXACT_STACK_BOUNDS)
+static _Atomic(LighterStackBoundFunction) original_stack_bound_function = NULL;
+static _Thread_local uintptr_t cached_stack_low = 0;
+static _Thread_local uintptr_t cached_stack_high = 0;
+static atomic_flag setup_lock = ATOMIC_FLAG_INIT;
+
+static void lock_setup(void) {
+    while (atomic_flag_test_and_set_explicit(
+        &setup_lock, memory_order_acquire
+    )) {
+        atomic_signal_fence(memory_order_seq_cst);
+    }
+}
+
+static void unlock_setup(void) {
+    atomic_flag_clear_explicit(&setup_lock, memory_order_release);
+}
+
+static void lighter_cached_stack_bounds(uintptr_t bounds[2]) {
+    char stack_marker;
+    uintptr_t stack_pointer = (uintptr_t)&stack_marker;
+
+    if (
+        cached_stack_low != 0 &&
+        stack_pointer > cached_stack_low &&
+        stack_pointer <= cached_stack_high
+    ) {
+        bounds[0] = cached_stack_low;
+        bounds[1] = cached_stack_high;
+        return;
+    }
+
+    /*
+     * Go deliberately refreshes these bounds because a C coroutine may have
+     * switched stacks. Reuse only bounds that were returned by the runtime's
+     * exact pthread lookup and that still contain the current stack pointer.
+     * A switched stack falls through to the original lookup and is not cached
+     * unless those exact bounds contain it.
+     */
+    LighterStackBoundFunction original = atomic_load_explicit(
+        &original_stack_bound_function, memory_order_acquire
+    );
+    if (original == NULL) {
+        bounds[0] = 0;
+        bounds[1] = 0;
+        return;
+    }
+    original(bounds);
+    if (
+        bounds[0] != 0 &&
+        stack_pointer > bounds[0] &&
+        stack_pointer <= bounds[1]
+    ) {
+        cached_stack_low = bounds[0];
+        cached_stack_high = bounds[1];
+    }
+}
+#endif
+
+LighterStackBoundFunction lighter_enable_stack_bound_cache(
+    LighterStackBoundFunction original
+) {
+#if !defined(LIGHTER_HAS_EXACT_STACK_BOUNDS)
+    /*
+     * Windows is already a no-op. Other libc fallbacks estimate bounds from
+     * the current frame, so caching them would weaken Go's stack-switching
+     * protection.
+     */
+    (void)original;
+    return NULL;
+#else
+    lock_setup();
+    if (original == lighter_cached_stack_bounds) {
+        unlock_setup();
+        return original;
+    }
+    if (original == NULL) {
+        unlock_setup();
+        return NULL;
+    }
+    atomic_store_explicit(
+        &original_stack_bound_function, original, memory_order_release
+    );
+    unlock_setup();
+    return lighter_cached_stack_bounds;
+#endif
+}

--- a/sharedlib/stack_bound_cache.h
+++ b/sharedlib/stack_bound_cache.h
@@ -1,0 +1,12 @@
+#ifndef LIGHTER_STACK_BOUND_CACHE_H
+#define LIGHTER_STACK_BOUND_CACHE_H
+
+#include <stdint.h>
+
+typedef void (*LighterStackBoundFunction)(uintptr_t bounds[2]);
+
+LighterStackBoundFunction lighter_enable_stack_bound_cache(
+    LighterStackBoundFunction original
+);
+
+#endif

--- a/sharedlib/stack_bound_cache_go123.go
+++ b/sharedlib/stack_bound_cache_go123.go
@@ -1,0 +1,49 @@
+//go:build cgo && !go1.26
+
+package main
+
+/*
+#include <stdint.h>
+typedef void (*LighterStackBoundFunction)(uintptr_t bounds[2]);
+LighterStackBoundFunction lighter_enable_stack_bound_cache(
+    LighterStackBoundFunction original
+);
+*/
+import "C"
+
+import (
+	"sync"
+	"sync/atomic"
+	"unsafe"
+)
+
+var (
+	stackBoundCacheEnableOnce   sync.Once
+	stackBoundCacheEnableResult C.int
+)
+
+// The standard Go runtime asks libc to rediscover a foreign thread's stack
+// bounds on every C-to-Go callback. The optional cache keeps exact pthread
+// bounds per thread and falls back whenever a caller has switched stacks.
+//
+// WARNING: _cgo_getstackbound is a private Go runtime hook with no compatibility
+// guarantee. This integration is limited by the build tag above, tied to the Go
+// toolchain in go.mod, and must be revalidated before every toolchain upgrade.
+//
+//go:linkname cgoGetStackbound _cgo_getstackbound
+var cgoGetStackbound unsafe.Pointer
+
+//export FastEnableStackBoundCache
+func FastEnableStackBoundCache() C.int {
+	stackBoundCacheEnableOnce.Do(func() {
+		original := atomic.LoadPointer(&cgoGetStackbound)
+		cached := C.lighter_enable_stack_bound_cache(
+			(C.LighterStackBoundFunction)(original),
+		)
+		if cached != nil {
+			atomic.StorePointer(&cgoGetStackbound, unsafe.Pointer(cached))
+			stackBoundCacheEnableResult = 1
+		}
+	})
+	return stackBoundCacheEnableResult
+}

--- a/sharedlib/stack_bound_cache_go126.go
+++ b/sharedlib/stack_bound_cache_go126.go
@@ -1,0 +1,16 @@
+//go:build cgo && go1.26
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+
+// FastEnableStackBoundCache is disabled on unvalidated Go toolchains. The
+// private runtime hook must be re-audited before raising the version guard.
+//
+//export FastEnableStackBoundCache
+func FastEnableStackBoundCache() C.int {
+	return 0
+}

--- a/signer/key_manager.go
+++ b/signer/key_manager.go
@@ -3,9 +3,12 @@ package signer
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"hash"
 	"math/big"
+	"runtime"
+	"sync"
 
 	curve "github.com/elliottech/poseidon_crypto/curve/ecgfp5"
 	gFp5 "github.com/elliottech/poseidon_crypto/field/goldilocks_quintic_extension"
@@ -24,32 +27,126 @@ type KeyManager interface {
 }
 
 type keyManager struct {
-	key curve.ECgFp5Scalar
+	key       curve.ECgFp5Scalar
+	publicKey gFp5.Element
+}
+
+const maxPreparedNoncePoolSize = 10_000
+
+var (
+	preparedNoncePool = make(chan *schnorr.PreparedNonce, maxPreparedNoncePoolSize)
+	prepareNonceMu    sync.Mutex
+)
+
+// PrepareSchnorrNonces moves the expensive fixed-generator multiplication out
+// of the latency-sensitive signing path. The pool is process-global: any key
+// manager may consume its entries. Each nonce is process-bound, held in memory
+// until it is used, and consumed exactly once. Prepared nonces must never be
+// serialized, persisted, or shared across a fork.
+func PrepareSchnorrNonces(count int) error {
+	if count < 0 {
+		return fmt.Errorf("prepared nonce count must be non-negative")
+	}
+	if count == 0 {
+		return nil
+	}
+
+	prepareNonceMu.Lock()
+	defer prepareNonceMu.Unlock()
+	if available := cap(preparedNoncePool) - len(preparedNoncePool); count > available {
+		return fmt.Errorf("prepared nonce pool has room for %d nonces, got %d", available, count)
+	}
+
+	nonces := make([]*schnorr.PreparedNonce, count)
+	workerCount := min(count, runtime.GOMAXPROCS(0))
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+	var prepareErr error
+	var prepareErrOnce sync.Once
+	for worker := 0; worker < workerCount; worker++ {
+		start := worker * count / workerCount
+		end := (worker + 1) * count / workerCount
+		go func() {
+			defer workers.Done()
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					prepareErrOnce.Do(func() {
+						prepareErr = fmt.Errorf("failed to prepare Schnorr nonce: %v", recovered)
+					})
+				}
+			}()
+			for i := start; i < end; i++ {
+				nonces[i] = schnorr.PrepareNonce()
+			}
+		}()
+	}
+	workers.Wait()
+	if prepareErr != nil {
+		return prepareErr
+	}
+	for _, nonce := range nonces {
+		preparedNoncePool <- nonce
+	}
+	return nil
+}
+
+func takePreparedSchnorrNonce() *schnorr.PreparedNonce {
+	select {
+	case nonce := <-preparedNoncePool:
+		return nonce
+	default:
+		return nil
+	}
 }
 
 // hex string seed should be at least 32 bytes when decoded
 func NewSeedKeyManager(seed string) (KeyManager, error) {
-	return &keyManager{key: GetScalarFromSeed(seed)}, nil
+	return newKeyManager(GetScalarFromSeed(seed)), nil
 }
-
 
 func NewKeyManager(b []byte) (KeyManager, error) {
 	if len(b) != 40 {
 		return nil, fmt.Errorf("invalid private key length. expected: 40 got: %v", len(b))
 	}
-	return &keyManager{key: curve.ScalarElementFromLittleEndianBytes(b)}, nil
+	return newKeyManager(curve.ScalarElementFromLittleEndianBytes(b)), nil
 }
 
-func (key *keyManager) Sign(hashedMessage []byte, hFunc hash.Hash) ([]byte, error) {
+func newKeyManager(key curve.ECgFp5Scalar) *keyManager {
+	curve.WarmGeneratorTable()
+	return &keyManager{
+		key:       key,
+		publicKey: schnorr.SchnorrPkFromSk(key),
+	}
+}
+
+func (key *keyManager) Sign(hashedMessage []byte, _ hash.Hash) ([]byte, error) {
+	return key.SignHash(hashedMessage)
+}
+
+// SignHash signs a canonical Fp5 message hash directly. Keeping this separate
+// from the legacy Sign method lets transaction construction avoid allocating a
+// hash.Hash value that the built-in signer does not use.
+func (key *keyManager) SignHash(hashedMessage []byte) ([]byte, error) {
 	hashedMessageAsQuinticExtension, err := gFp5.FromCanonicalLittleEndianBytes(hashedMessage)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse message while signing. message: %v err: %w", hashedMessage, err)
+	}
+	if nonce := takePreparedSchnorrNonce(); nonce != nil {
+		signature, err := schnorr.SchnorrSignHashedMessagePrepared(
+			hashedMessageAsQuinticExtension, key.key, nonce,
+		)
+		if err == nil {
+			return signature.ToBytes(), nil
+		}
+		if !errors.Is(err, schnorr.ErrPreparedNonceForked) {
+			return nil, fmt.Errorf("failed to sign with prepared nonce: %w", err)
+		}
 	}
 	return schnorr.SchnorrSignHashedMessage(hashedMessageAsQuinticExtension, key.key).ToBytes(), nil
 }
 
 func (key *keyManager) PubKey() gFp5.Element {
-	return schnorr.SchnorrPkFromSk(key.key)
+	return key.publicKey
 }
 
 func (key *keyManager) PubKeyBytes() (res [40]byte) {
@@ -61,7 +158,6 @@ func (key *keyManager) PubKeyBytes() (res [40]byte) {
 func (key *keyManager) PrvKeyBytes() []byte {
 	return key.key.ToLittleEndianBytes()
 }
-
 
 func GetScalarFromSeed(seed string) curve.ECgFp5Scalar {
 	seedBytes, err := hex.DecodeString(seed)

--- a/signer/key_manager_test.go
+++ b/signer/key_manager_test.go
@@ -1,0 +1,73 @@
+package signer
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	curve "github.com/elliottech/poseidon_crypto/curve/ecgfp5"
+	g "github.com/elliottech/poseidon_crypto/field/goldilocks"
+	p2 "github.com/elliottech/poseidon_crypto/hash/poseidon2_goldilocks_plonky2"
+	schnorr "github.com/elliottech/poseidon_crypto/signature/schnorr"
+)
+
+func TestNewSeedKeyManagerCachesMatchingPublicKey(t *testing.T) {
+	seed := strings.Repeat("01", 32)
+	key, err := NewSeedKeyManager(seed)
+	if err != nil {
+		t.Fatalf("new seed key manager: %v", err)
+	}
+	want := schnorr.SchnorrPkFromSk(GetScalarFromSeed(seed))
+	if got := key.PubKey(); got != want {
+		t.Fatalf("seed public key = %v, want %v", got, want)
+	}
+}
+
+func drainPreparedNoncePool() {
+	for {
+		select {
+		case <-preparedNoncePool:
+		default:
+			return
+		}
+	}
+}
+
+func TestPreparedNoncePoolConcurrentSignatures(t *testing.T) {
+	drainPreparedNoncePool()
+	t.Cleanup(drainPreparedNoncePool)
+
+	const signatureCount = 256
+	if err := PrepareSchnorrNonces(signatureCount); err != nil {
+		t.Fatalf("prepare nonces: %v", err)
+	}
+	key, err := NewKeyManager(curve.SampleScalar().ToLittleEndianBytes())
+	if err != nil {
+		t.Fatalf("new key manager: %v", err)
+	}
+	publicKey := key.PubKeyBytes()
+
+	var workers sync.WaitGroup
+	for i := range signatureCount {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			message := p2.HashToQuinticExtension([]g.GoldilocksField{
+				g.GoldilocksField(i + 1),
+			}).ToLittleEndianBytes()
+			signature, signErr := key.Sign(message, nil)
+			if signErr != nil {
+				t.Errorf("sign message %d: %v", i, signErr)
+				return
+			}
+			if validateErr := schnorr.Validate(publicKey[:], message, signature); validateErr != nil {
+				t.Errorf("validate message %d: %v", i, validateErr)
+			}
+		}()
+	}
+	workers.Wait()
+
+	if remaining := len(preparedNoncePool); remaining != 0 {
+		t.Fatalf("prepared nonce pool contains %d unused entries", remaining)
+	}
+}

--- a/types/tx_request.go
+++ b/types/tx_request.go
@@ -34,6 +34,17 @@ type L2TxAttributes struct {
 
 type PublicKey = gFp5.Element
 
+type directHashSigner interface {
+	SignHash(message []byte) ([]byte, error)
+}
+
+func signHashedMessage(key signer.Signer, message []byte) ([]byte, error) {
+	if direct, ok := key.(directHashSigner); ok {
+		return direct.SignHash(message)
+	}
+	return key.Sign(message, p2.NewPoseidon2())
+}
+
 type ChangePubKeyReq struct {
 	PubKey [40]byte
 }
@@ -169,7 +180,7 @@ func ConstructAuthToken(key signer.Signer, deadline time.Time, ops *TransactOpts
 
 	msgHash := p2.HashToQuinticExtension(msgInField).ToLittleEndianBytes()
 
-	signatureBytes, err := key.Sign(msgHash, p2.NewPoseidon2())
+	signatureBytes, err := signHashedMessage(key, msgHash)
 	if err != nil {
 		return "", err
 	}
@@ -226,7 +237,7 @@ func ConstructChangePubKeyTx(key signer.Signer, lighterChainId uint32, tx *Chang
 		return nil, err
 	}
 
-	signature, err := key.Sign(msgHash, p2.NewPoseidon2())
+	signature, err := signHashedMessage(key, msgHash)
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +259,7 @@ func ConstructCreateSubAccountTx(key signer.Signer, lighterChainId uint32, ops *
 		return nil, err
 	}
 
-	signature, err := key.Sign(msgHash, p2.NewPoseidon2())
+	signature, err := signHashedMessage(key, msgHash)
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +281,7 @@ func ConstructCreatePublicPoolTx(key signer.Signer, lighterChainId uint32, tx *C
 		return nil, err
 	}
 
-	signature, err := key.Sign(msgHash, p2.NewPoseidon2())
+	signature, err := signHashedMessage(key, msgHash)
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +303,7 @@ func ConstructUpdatePublicPoolTx(key signer.Signer, lighterChainId uint32, tx *U
 		return nil, err
 	}
 
-	signature, err := key.Sign(msgHash, p2.NewPoseidon2())
+	signature, err := signHashedMessage(key, msgHash)
 	if err != nil {
 		return nil, err
 	}
@@ -314,7 +325,7 @@ func ConstructWithdrawTx(key signer.Signer, lighterChainId uint32, tx *WithdrawT
 		return nil, err
 	}
 
-	signature, err := key.Sign(msgHash, p2.NewPoseidon2())
+	signature, err := signHashedMessage(key, msgHash)
 	if err != nil {
 		return nil, err
 	}
@@ -336,7 +347,7 @@ func ConstructCreateOrderTx(key signer.Signer, lighterChainId uint32, tx *Create
 		return nil, err
 	}
 
-	signature, err := key.Sign(msgHash, p2.NewPoseidon2())
+	signature, err := signHashedMessage(key, msgHash)
 	if err != nil {
 		return nil, err
 	}
@@ -358,7 +369,7 @@ func ConstructL2CreateGroupedOrdersTx(key signer.Signer, lighterChainId uint32, 
 		return nil, err
 	}
 
-	signature, err := key.Sign(msgHash, p2.NewPoseidon2())
+	signature, err := signHashedMessage(key, msgHash)
 	if err != nil {
 		return nil, err
 	}
@@ -380,7 +391,7 @@ func ConstructL2CancelOrderTx(key signer.Signer, lighterChainId uint32, tx *Canc
 		return nil, err
 	}
 
-	signature, err := key.Sign(msgHash, p2.NewPoseidon2())
+	signature, err := signHashedMessage(key, msgHash)
 	if err != nil {
 		return nil, err
 	}
@@ -402,7 +413,7 @@ func ConstructL2ModifyOrderTx(key signer.Signer, lighterChainId uint32, tx *Modi
 		return nil, err
 	}
 
-	signature, err := key.Sign(msgHash, p2.NewPoseidon2())
+	signature, err := signHashedMessage(key, msgHash)
 	if err != nil {
 		return nil, err
 	}
@@ -424,7 +435,7 @@ func ConstructStakeAssetsTx(key signer.Signer, lighterChainId uint32, tx *StakeA
 		return nil, err
 	}
 
-	signature, err := key.Sign(msgHash, p2.NewPoseidon2())
+	signature, err := signHashedMessage(key, msgHash)
 	if err != nil {
 		return nil, err
 	}
@@ -446,7 +457,7 @@ func ConstructUnstakeAssetsTx(key signer.Signer, lighterChainId uint32, tx *Unst
 		return nil, err
 	}
 
-	signature, err := key.Sign(msgHash, p2.NewPoseidon2())
+	signature, err := signHashedMessage(key, msgHash)
 	if err != nil {
 		return nil, err
 	}
@@ -468,7 +479,7 @@ func ConstructL2CancelAllOrdersTx(key signer.Signer, lighterChainId uint32, tx *
 		return nil, err
 	}
 
-	signature, err := key.Sign(msgHash, p2.NewPoseidon2())
+	signature, err := signHashedMessage(key, msgHash)
 	if err != nil {
 		return nil, err
 	}
@@ -491,7 +502,7 @@ func ConstructApproveIntegratorTx(key signer.Signer, lighterChainId uint32, tx *
 		return nil, err
 	}
 
-	signature, err := key.Sign(msgHash, p2.NewPoseidon2())
+	signature, err := signHashedMessage(key, msgHash)
 	if err != nil {
 		return nil, err
 	}
@@ -513,7 +524,7 @@ func ConstructTransferTx(key signer.Signer, lighterChainId uint32, tx *TransferT
 		return nil, err
 	}
 
-	signature, err := key.Sign(msgHash, p2.NewPoseidon2())
+	signature, err := signHashedMessage(key, msgHash)
 	if err != nil {
 		return nil, err
 	}
@@ -535,7 +546,7 @@ func ConstructMintSharesTx(key signer.Signer, lighterChainId uint32, tx *MintSha
 		return nil, err
 	}
 
-	signature, err := key.Sign(msgHash, p2.NewPoseidon2())
+	signature, err := signHashedMessage(key, msgHash)
 	if err != nil {
 		return nil, err
 	}
@@ -557,7 +568,7 @@ func ConstructBurnSharesTx(key signer.Signer, lighterChainId uint32, tx *BurnSha
 		return nil, err
 	}
 
-	signature, err := key.Sign(msgHash, p2.NewPoseidon2())
+	signature, err := signHashedMessage(key, msgHash)
 	if err != nil {
 		return nil, err
 	}
@@ -579,7 +590,7 @@ func ConstructUpdateLeverageTx(key signer.Signer, lighterChainId uint32, tx *Upd
 		return nil, err
 	}
 
-	signature, err := key.Sign(msgHash, p2.NewPoseidon2())
+	signature, err := signHashedMessage(key, msgHash)
 	if err != nil {
 		return nil, err
 	}
@@ -601,7 +612,7 @@ func ConstructUpdateMarginTx(key signer.Signer, lighterChainId uint32, tx *Updat
 		return nil, err
 	}
 
-	signature, err := key.Sign(msgHash, p2.NewPoseidon2())
+	signature, err := signHashedMessage(key, msgHash)
 	if err != nil {
 		return nil, err
 	}
@@ -623,7 +634,7 @@ func ConstructUpdateAccountConfigTx(key signer.Signer, lighterChainId uint32, tx
 		return nil, err
 	}
 
-	signature, err := key.Sign(msgHash, p2.NewPoseidon2())
+	signature, err := signHashedMessage(key, msgHash)
 	if err != nil {
 		return nil, err
 	}
@@ -645,7 +656,7 @@ func ConstructUpdateAccountAssetConfigTx(key signer.Signer, lighterChainId uint3
 		return nil, err
 	}
 
-	signature, err := key.Sign(msgHash, p2.NewPoseidon2())
+	signature, err := signHashedMessage(key, msgHash)
 	if err != nil {
 		return nil, err
 	}

--- a/types/tx_request_test.go
+++ b/types/tx_request_test.go
@@ -1,0 +1,129 @@
+package types
+
+import (
+	"hash"
+	"testing"
+	"time"
+
+	"github.com/elliottech/lighter-go/signer"
+	curve "github.com/elliottech/poseidon_crypto/curve/ecgfp5"
+)
+
+type legacyTestSigner struct {
+	called bool
+	hash   hash.Hash
+}
+
+func (signer *legacyTestSigner) Sign(_ []byte, h hash.Hash) ([]byte, error) {
+	signer.called = true
+	signer.hash = h
+	return []byte("legacy"), nil
+}
+
+type directTestSigner struct {
+	legacyCalled bool
+	directCalled bool
+}
+
+func (signer *directTestSigner) Sign(_ []byte, _ hash.Hash) ([]byte, error) {
+	signer.legacyCalled = true
+	return []byte("legacy"), nil
+}
+
+func (signer *directTestSigner) SignHash(_ []byte) ([]byte, error) {
+	signer.directCalled = true
+	return []byte("direct"), nil
+}
+
+func TestSignHashedMessageUsesDirectSigner(t *testing.T) {
+	signer := &directTestSigner{}
+	signature, err := signHashedMessage(signer, []byte("message"))
+	if err != nil {
+		t.Fatalf("sign hashed message: %v", err)
+	}
+	if string(signature) != "direct" || !signer.directCalled || signer.legacyCalled {
+		t.Fatalf("direct signer was not selected: %+v", signer)
+	}
+}
+
+func TestSignHashedMessageSupportsLegacySigner(t *testing.T) {
+	signer := &legacyTestSigner{}
+	signature, err := signHashedMessage(signer, []byte("message"))
+	if err != nil {
+		t.Fatalf("sign hashed message: %v", err)
+	}
+	if string(signature) != "legacy" || !signer.called || signer.hash == nil {
+		t.Fatalf("legacy signer fallback was not used: %+v", signer)
+	}
+}
+
+func benchmarkCreateOrder(b *testing.B) (signer.KeyManager, *CreateOrderTxReq, *TransactOpts) {
+	b.Helper()
+	key, err := signer.NewKeyManager(curve.ONE.ToLittleEndianBytes())
+	if err != nil {
+		b.Fatalf("new key manager: %v", err)
+	}
+	accountIndex := int64(1)
+	apiKeyIndex := uint8(0)
+	nonce := int64(1)
+	return key, &CreateOrderTxReq{
+			MarketIndex:      0,
+			ClientOrderIndex: 1,
+			BaseAmount:       10_000,
+			Price:            1_000,
+			Type:             0,
+			TimeInForce:      1,
+			OrderExpiry:      time.Now().Add(24 * time.Hour).UnixMilli(),
+		}, &TransactOpts{
+			FromAccountIndex: &accountIndex,
+			ApiKeyIndex:      &apiKeyIndex,
+			ExpiredAt:        time.Now().Add(10 * time.Minute).UnixMilli(),
+			Nonce:            &nonce,
+		}
+}
+
+func BenchmarkCreateOrderStages(b *testing.B) {
+	key, order, opts := benchmarkCreateOrder(b)
+	converted := ConvertCreateOrderTx(order, opts)
+	messageHash, err := converted.Hash(304)
+	if err != nil {
+		b.Fatalf("hash order: %v", err)
+	}
+	signed, err := ConstructCreateOrderTx(key, 304, order, opts)
+	if err != nil {
+		b.Fatalf("construct order: %v", err)
+	}
+
+	b.Run("hash", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if _, err := converted.Hash(304); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("sign", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if _, err := signHashedMessage(key, messageHash); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("serialize", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if _, err := signed.GetTxInfo(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("complete", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if _, err := ConstructCreateOrderTx(key, 304, order, opts); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Result: ~30× faster normal single-order signing

**Normal order latency: 1.95–2.02 ms → 63.9 µs**

**Sequential signing throughput: roughly 500 → 15,700 orders/sec**

**That is approximately 96.7% less latency without changing how callers sign an order.**

This is the existing one-order-at-a-time `SignCreateOrder` / Python `sign_create_order` path. It requires **no batching and no prepared nonces**. The headline improvement is the normal path; batching and nonce preparation are optional secondary optimizations.

The 1.95–2.02 ms baseline is the original warm end-to-end caller measurement on this host. The 63.9 µs result is the public Python signing call over 7 × 1,000 sequential orders on the same host. Against the bundled signer's directly measured 1,644 µs public Python path, the new path is still 25.7× faster.

> [!IMPORTANT]
> The main C-to-Go callback speedup depends on Go's private `_cgo_getstackbound` hook via `//go:linkname`. This is unsupported runtime internals, has no compatibility guarantee, and **must be explicitly accepted and revalidated on every Go toolchain upgrade**. The implementation is pinned to the repository's Go 1.23 toolchain and disabled by a `go1.26` guard until that version is audited.

## Summary

Speed up the normal, one-order signing path exposed by the shared library. This is the primary change; callers do not need to batch or precompute anything to benefit.

- use the optimized fixed-generator Schnorr implementation from the linked Poseidon PR
- bypass an unused `hash.Hash` allocation in the built-in signer
- cache the public key and warm the fixed-generator table during client setup
- cache exact foreign-thread stack bounds around C-to-Go callbacks on supported libc implementations
- retain the public single-order `SignCreateOrder` API

On an Intel Xeon E-2286G (Go 1.23, CPython 3.12, glibc, main thread), the complete public Python `sign_create_order` call is 63.9 µs/order (median, 7 × 1,000 orders), about 15.7k orders/sec. The previous bundled signer measured 816.5 µs/order even after separately applying direct POSIX response cleanup, and 1,644 µs/order with its normal exported-Go cleanup.

The private-hook contribution is platform and thread dependent. In a no-op C-to-Go callback microbenchmark on this host, main-thread callback cost changed from about 279.5 µs to 1.54 µs; a worker-thread run changed from about 3.18 µs to 1.52 µs. macOS already has an O(1) runtime lookup, while Windows and libc fallbacks without exact pthread bounds intentionally do not install this cache.

The cache stores exact bounds per native thread and rechecks that the current stack pointer remains inside them on every callback. A coroutine or alternate stack falls through to the original runtime lookup. Setup uses atomic acquire/release publication, is idempotent, and has a version-gated no-op fallback.

## Secondary improvements

### Prepared nonces

An opt-in process-global pool can move Schnorr commitment generation outside a signing burst. Normal signing does not use it unless the pool is explicitly filled. Prepared single-order signing measured 14.8 µs/order on the same host. Nonces are single-use, process-bound, memory-only, and must not be serialized or shared across a fork.

### Explicit batch API

`SignCreateOrdersBatch` signs independent orders with consecutive explicit nonces using up to `GOMAXPROCS` workers and returns one packed allocation. It is only used when the caller invokes the new batch API; a normal single `SignCreateOrder` call is never routed through batching.

For batches of 1,000 orders, the public Python path measured:

| Mode | Median | Throughput |
|---|---:|---:|
| normal batch | 10.5 µs/order | 94.9k/sec |
| prepared batch | 3.24 µs/order | 308k/sec |

Batch input is capped at 10,000, requires a non-negative explicit first nonce, rejects nonce overflow, uses the client's resolved account/API-key indices, and records per-order errors without corrupting adjacent results.

## Dependency / merge order

This draft temporarily pins the Poseidon fork commit with a pseudo-version. Please merge and tag the linked Poseidon change as `v0.0.19`, bump the `github.com/elliottech/poseidon_crypto` requirement to `v0.0.19`, delete the temporary fork `replace`, and only then merge this PR.

The dependency pin is intentionally isolated in the final commit, so only the branch tip builds; the preceding implementation commit by itself still sees the old Poseidon API.

- Poseidon speedup: [elliottech/poseidon_crypto#38](https://github.com/elliottech/poseidon_crypto/pull/38)
- Python wrapper: [elliottech/lighter-python#165](https://github.com/elliottech/lighter-python/pull/165)

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- Linux c-shared build and generated-header/C++ consumer build
- Windows amd64 c-shared cross-build with MinGW and C11 atomics
- stack-cache idempotence and callback tests
- batch defaults, bounds, mixed-error, packing, and 2,000-order race/uniqueness tests
