### PR TITLE
fix: scope API key cache by endpoint

### DIFF
--- a/client/http/requests.go
+++ b/client/http/requests.go
@@ -64,6 +64,7 @@ func (c *client) GetNextNonce(accountIndex int64, apiKeyIndex uint8) (int64, err
 }
 
 type apiKeyCacheKey struct {
+	endpoint     string
 	accountIndex int64
 	apiKeyIndex  uint8
 }
@@ -74,7 +75,7 @@ var (
 )
 
 func (c *client) GetApiKey(accountIndex int64, apiKeyIndex uint8) (string, error) {
-	cacheKey := apiKeyCacheKey{accountIndex: accountIndex, apiKeyIndex: apiKeyIndex}
+	cacheKey := apiKeyCacheKey{endpoint: c.endpoint, accountIndex: accountIndex, apiKeyIndex: apiKeyIndex}
 
 	apiKeyCacheMu.RLock()
 	if cached, ok := apiKeyCache[cacheKey]; ok {
@@ -90,12 +91,12 @@ func (c *client) GetApiKey(accountIndex int64, apiKeyIndex uint8) (string, error
 
 	apiKeyCacheMu.Lock()
 	for k := range apiKeyCache {
-		if k.accountIndex == accountIndex {
+		if k.endpoint == c.endpoint && k.accountIndex == accountIndex {
 			delete(apiKeyCache, k)
 		}
 	}
 	for _, apiKey := range result.ApiKeys {
-		apiKeyCache[apiKeyCacheKey{accountIndex: accountIndex, apiKeyIndex: apiKey.ApiKeyIndex}] = apiKey.PublicKey
+		apiKeyCache[apiKeyCacheKey{endpoint: c.endpoint, accountIndex: accountIndex, apiKeyIndex: apiKey.ApiKeyIndex}] = apiKey.PublicKey
 	}
 	key, ok := apiKeyCache[cacheKey]
 	apiKeyCacheMu.Unlock()
@@ -109,7 +110,7 @@ func (c *client) InvalidateApiKeys(accountIndex int64) {
 	apiKeyCacheMu.Lock()
 	defer apiKeyCacheMu.Unlock()
 	for k := range apiKeyCache {
-		if k.accountIndex == accountIndex {
+		if k.endpoint == c.endpoint && k.accountIndex == accountIndex {
 			delete(apiKeyCache, k)
 		}
 	}

--- a/client/http/requests_test.go
+++ b/client/http/requests_test.go
@@ -1,0 +1,72 @@
+package http
+
+import (
+	"encoding/json"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestApiKeyCacheIsScopedByEndpoint(t *testing.T) {
+	const (
+		accountIndex = int64(987654321)
+		apiKeyIndex  = uint8(0)
+	)
+
+	newServer := func(publicKey string, requests *atomic.Int32) *httptest.Server {
+		return httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+			requests.Add(1)
+			if r.URL.Path != "/api/v1/apikeys" {
+				t.Fatalf("unexpected request path: %s", r.URL.Path)
+			}
+			if got := r.URL.Query().Get("account_index"); got != "987654321" {
+				t.Fatalf("unexpected account_index: %s", got)
+			}
+
+			if err := json.NewEncoder(w).Encode(AccountApiKeys{
+				ResultCode: ResultCode{Code: CodeOK},
+				ApiKeys: []*ApiKey{{
+					AccountIndex: accountIndex,
+					ApiKeyIndex:  apiKeyIndex,
+					PublicKey:    publicKey,
+				}},
+			}); err != nil {
+				t.Fatalf("encode response: %v", err)
+			}
+		}))
+	}
+
+	var requestsA, requestsB atomic.Int32
+	serverA := newServer("key-a", &requestsA)
+	defer serverA.Close()
+	serverB := newServer("key-b", &requestsB)
+	defer serverB.Close()
+
+	clientA := NewClient(serverA.URL)
+	clientB := NewClient(serverB.URL)
+
+	keyA, err := clientA.GetApiKey(accountIndex, apiKeyIndex)
+	if err != nil {
+		t.Fatalf("get API key from endpoint A: %v", err)
+	}
+	if keyA != "key-a" {
+		t.Fatalf("endpoint A returned %q, want %q", keyA, "key-a")
+	}
+
+	keyB, err := clientB.GetApiKey(accountIndex, apiKeyIndex)
+	if err != nil {
+		t.Fatalf("get API key from endpoint B: %v", err)
+	}
+	if keyB != "key-b" {
+		t.Fatalf("endpoint B returned %q, want %q", keyB, "key-b")
+	}
+
+	clientA.InvalidateApiKeys(accountIndex)
+	if _, err := clientB.GetApiKey(accountIndex, apiKeyIndex); err != nil {
+		t.Fatalf("get cached API key from endpoint B: %v", err)
+	}
+	if got := requestsB.Load(); got != 1 {
+		t.Fatalf("endpoint B received %d requests after endpoint A invalidation, want 1", got)
+	}
+}


### PR DESCRIPTION
## Summary

- scope API key cache entries by the HTTP client's endpoint
- restrict account-level invalidation to keys cached for that endpoint
- add a two-server regression test covering both reads and invalidation

Without endpoint scoping, clients connected to different deployments can return or evict each other's API keys when their account and API key indexes overlap.

Fixes #86.

## Testing

- `go test ./...`
- `go vet ./...`